### PR TITLE
feat: 月令從重・四病四薬と調候突合を接続

### DIFF
--- a/chrome-extension/docs/design/病薬表示オプション/06_実装計画と未決事項.md
+++ b/chrome-extension/docs/design/病薬表示オプション/06_実装計画と未決事項.md
@@ -1,6 +1,6 @@
 # 06. 実装計画と決定事項
 
-設計レビューは **承認**（PR#11）。D-01〜D-08および R-01〜R-03 は完了済。現在 Sprint B2。
+設計レビューは **承認**（PR#11）。D-01〜D-08および R-01〜R-03 は完了済。現在 Sprint B3。
 
 | ID | 実装前のP0確認 | 完了条件 |
 |----|----------------|----------|
@@ -22,12 +22,12 @@
 | T-03a | `KeizenAnalyzer`（主軸・用神損傷） | `js/core/KeizenAnalyzer.js` + テスト | **完了**（KZ-01〜04相当） |
 | T-03b | `KishouAssessor`（寒暖・燥湿、清濁=`不明`）※格局より前 | `js/core/KishouAssessor.js` + テスト | **完了**（標準柱ウェイト適用） |
 | T-03c | 月令ブースト從重＋四病四薬接続 | `ByoyakuCalculator` 拡張 | **完了** |
-| T-03d | 調候方向と十神薬の突合・病薬バランス | `ByoyakuCalculator` + 表示 | **完了** |
+| T-03d | 調候方向と十神薬の突合・病薬バランス | `ByoyakuCalculator` + 単体テスト | **完了**（Keizen breaks接続含む） |
 | T-03e | `diagnose(object)` v2 API 化 | `ByoyakuCalculator` | **完了** |
 | T-04 | ResultRenderer（気象→主軸→病薬→バランス→喜忌） | `ResultRenderer.js` | 待ち |
 | T-05 | 現行結果内 `#kakkyoku-toggle` を廃止／置換 | HTML + JS | **完了** |
 | T-06 | オプション永続化 | — | **見送り**（D-05） |
-| T-07 | 既存テスト＋三篇シナリオ＋OFF時非実行spy | `npm test` / 手動手順 | **一部完了**（116件green、AC-01/02＋D-04ハンドラ単体。UI受入は未実施） |
+| T-07 | 既存テスト＋三篇シナリオ＋OFF時非実行spy | `npm test` / 手動手順 | **一部完了**（128件green、AC-01/02・AC-05＋D-04ハンドラ単体。UI受入は未実施） |
 | T-08 | USER_GUIDE / manifest 説明の更新 | docs / manifest | 待ち |
 
 詳細なフェーズ分割は [11_実行計画.md](../病薬表示機能_詳細設計/11_実行計画.md) を正とする。

--- a/chrome-extension/docs/design/病薬表示オプション/06_実装計画と未決事項.md
+++ b/chrome-extension/docs/design/病薬表示オプション/06_実装計画と未決事項.md
@@ -21,8 +21,8 @@
 | T-03 | AppController に feature flag と計算分岐を実装 | `AppController.js` / `byoyakuPipeline.js` | **完了**（D-04計算済みガード含む） |
 | T-03a | `KeizenAnalyzer`（主軸・用神損傷） | `js/core/KeizenAnalyzer.js` + テスト | **完了**（KZ-01〜04相当） |
 | T-03b | `KishouAssessor`（寒暖・燥湿、清濁=`不明`）※格局より前 | `js/core/KishouAssessor.js` + テスト | **完了**（標準柱ウェイト適用） |
-| T-03c | 月令ブースト從重＋四病四薬接続 | `ByoyakuCalculator` 拡張 | 待ち（R-01/R-02 v1.1で仕様確定） |
-| T-03d | 調候方向と十神薬の突合・病薬バランス | `ByoyakuCalculator` + 表示 | 待ち |
+| T-03c | 月令ブースト從重＋四病四薬接続 | `ByoyakuCalculator` 拡張 | **完了** |
+| T-03d | 調候方向と十神薬の突合・病薬バランス | `ByoyakuCalculator` + 表示 | **完了** |
 | T-03e | `diagnose(object)` v2 API 化 | `ByoyakuCalculator` | **完了** |
 | T-04 | ResultRenderer（気象→主軸→病薬→バランス→喜忌） | `ResultRenderer.js` | 待ち |
 | T-05 | 現行結果内 `#kakkyoku-toggle` を廃止／置換 | HTML + JS | **完了** |
@@ -37,8 +37,8 @@
 ```text
 T-01 / T-01b / T-01c（完了・PR#11）
   → Sprint B1: T-02 / T-03 / T-05 / OFF時spy  ← 完了
-  → Sprint B2: T-03b / T-03a / T-03e 完了 → T-03c → T-03d  ← 次
-  → Sprint B3: T-04 / T-07 / T-08
+  → Sprint B2: T-03b / a / e / c / d 完了
+  → Sprint B3: T-04 / T-07 / T-08  ← 次
 ```
 
 ## 3. 決定事項
@@ -155,8 +155,8 @@ T-01 / T-01b / T-01c（完了・PR#11）
 
 ## 6. 次アクション
 
-1. ~~Phase A / Sprint B1~~ → **完了**
-2. **Sprint B2:** T-03c（月令ブースト從重＋四病四薬接続）→ T-03d（調候突合・バランス）
-3. Sprint B3（UI詳細・受入・ガイド）
+1. ~~Phase A / Sprint B1 / Sprint B2 コア~~ → **完了**
+2. **Sprint B3:** T-04 ResultRenderer（気象→主軸→病薬→バランス→喜忌）
+3. T-07 受入 S-01〜S-07 / T-08 ガイド・manifest
 
 進捗の単一参照先: [11_実行計画.md](../病薬表示機能_詳細設計/11_実行計画.md)

--- a/chrome-extension/docs/design/病薬表示機能_詳細設計/11_実行計画.md
+++ b/chrome-extension/docs/design/病薬表示機能_詳細設計/11_実行計画.md
@@ -5,7 +5,7 @@
 | 基準日 | 2026-08-09 |
 | ブランチ | `feature/byoyaku-sprint-b1` |
 | 直前の成果 | PR [#11](https://github.com/m-tomei/pillars-addin/pull/11) マージ（Phase A 承認） |
-| 現フェーズ | **Sprint B2（T-03b/a/e完了 → T-03cへ）** |
+| 現フェーズ | **Sprint B2（T-03c/d完了 → Sprint B3へ）** |
 | 実装着手条件 | 満た済 |
 
 ---
@@ -21,8 +21,8 @@
 | T-03 | AppController 分岐（feature flag） | **完了** | `byoyakuPipeline.js`＋D-04計算済みガード |
 | T-03a | `KeizenAnalyzer`（主軸・用神損傷） | **完了** | `KeizenAnalyzer.js`＋KZ-01〜04相当テスト |
 | T-03b | `KishouAssessor`（寒暖・燥湿、清濁=不明） | **完了** | 標準柱ウェイト適用＋KS/閾値テスト |
-| T-03c | 月令ブースト從重＋四病四薬接続 | 待ち | Sprint B2 |
-| T-03d | 調候×十神薬突合・病薬バランス | 待ち | Sprint B2 |
+| T-03c | 月令ブースト從重＋四病四薬接続 | **完了** | 月令×2・從重40%・生/長/琢 |
+| T-03d | 調候×十神薬突合・病薬バランス | **完了** | balance / kiki / 副薬併記 |
 | T-03e | `diagnose(object)` v2 API 化 | **完了** | object必須・位置引数はアダプタ |
 | T-04 | ResultRenderer（気象→主軸→病薬→バランス→喜忌） | 待ち | Sprint B3 |
 | T-05 | `#kakkyoku-toggle` 廃止／計算前スイッチへ置換 | **完了** | 病薬診断見出しへ |

--- a/chrome-extension/docs/design/病薬表示機能_詳細設計/11_実行計画.md
+++ b/chrome-extension/docs/design/病薬表示機能_詳細設計/11_実行計画.md
@@ -3,9 +3,9 @@
 | 項目 | 内容 |
 |------|------|
 | 基準日 | 2026-08-09 |
-| ブランチ | `feature/byoyaku-sprint-b1` |
-| 直前の成果 | PR [#11](https://github.com/m-tomei/pillars-addin/pull/11) マージ（Phase A 承認） |
-| 現フェーズ | **Sprint B2（T-03c/d完了 → Sprint B3へ）** |
+| ブランチ | `feature/byoyaku-t03c-four-disease` |
+| 直前の成果 | PR [#12](https://github.com/m-tomei/pillars-addin/pull/12) マージ（Sprint B1＋B2基盤） |
+| 現フェーズ | **Sprint B3（T-04 / T-07 / T-08）** |
 | 実装着手条件 | 満た済 |
 
 ---
@@ -22,12 +22,12 @@
 | T-03a | `KeizenAnalyzer`（主軸・用神損傷） | **完了** | `KeizenAnalyzer.js`＋KZ-01〜04相当テスト |
 | T-03b | `KishouAssessor`（寒暖・燥湿、清濁=不明） | **完了** | 標準柱ウェイト適用＋KS/閾値テスト |
 | T-03c | 月令ブースト從重＋四病四薬接続 | **完了** | 月令×2・從重40%・生/長/琢 |
-| T-03d | 調候×十神薬突合・病薬バランス | **完了** | balance / kiki / 副薬併記 |
+| T-03d | 調候×十神薬突合・病薬バランス | **完了** | Keizen breaks接続、balance / kiki / 副薬併記 |
 | T-03e | `diagnose(object)` v2 API 化 | **完了** | object必須・位置引数はアダプタ |
 | T-04 | ResultRenderer（気象→主軸→病薬→バランス→喜忌） | 待ち | Sprint B3 |
 | T-05 | `#kakkyoku-toggle` 廃止／計算前スイッチへ置換 | **完了** | 病薬診断見出しへ |
 | T-06 | オプション永続化 | **見送り** | D-05=セッションのみ |
-| T-07 | 単体・結合・受入テスト | **一部完了** | 116件green。AC-01/02＋D-04ハンドラ単体済、UI受入は未実施 |
+| T-07 | 単体・結合・受入テスト | **一部完了** | 128件green。AC-01/02・AC-05＋D-04ハンドラ単体済、UI受入は未実施 |
 | T-08 | USER_GUIDE / manifest 更新 | 待ち | Sprint B3 |
 
 ---
@@ -63,7 +63,7 @@
 
 ---
 
-## 3. Phase B — 実装（今ここ: Sprint B2）
+## 3. Phase B — 実装（今ここ: Sprint B3）
 
 推奨スプリント分割:
 
@@ -101,21 +101,22 @@ T-08 ガイド／manifest
 
 1. ~~Phase A~~ → **完了（PR#11）**
 2. ~~Sprint B1: T-02 / T-03 / T-05 / AC-01・02~~ → **完了**
-3. **Sprint B2:** T-03c（月令ブースト從重＋四病四薬接続）→ T-03d（調候突合・バランス）
+3. ~~Sprint B2: T-03a〜e（病薬コア）~~ → **完了**
+4. **Sprint B3:** T-04（表示）→ T-07（受入）→ T-08（ガイド／manifest）
 
 ---
 
 ## 5. 依存関係（要約）
 
 ```text
-PR#11 マージ済（Phase A 承認）
+PR#12 マージ済（Sprint B1＋B2基盤）
         │
         ▼
    Sprint B1（スイッチ＋分岐）  完了
         │
         ▼
-   Sprint B2（気象・継善・病薬コア）  ← 現在地
+   Sprint B2（気象・継善・病薬コア）  完了
         │
         ▼
-   Sprint B3（UI・受入・ドキュメント）
+   Sprint B3（UI・受入・ドキュメント）  ← 現在地
 ```

--- a/chrome-extension/docs/design/病薬表示機能_詳細設計/README.md
+++ b/chrome-extension/docs/design/病薬表示機能_詳細設計/README.md
@@ -38,5 +38,6 @@
 
 - PR#11 マージ済。Phase A **承認**
 - Sprint B1 完了（スイッチ／計算分岐／旧トグル廃止）
-- Sprint B2 進行中（KishouAssessor / KeizenAnalyzer / object API 完了 → 次は T-03c）
+- Sprint B2 完了（気象・継善・從重・四病四薬・調候突合）
+- Sprint B3 進行中（次は T-04 ResultRenderer）
 - 詳細: [11_実行計画.md](./11_実行計画.md)

--- a/chrome-extension/js/core/ByoyakuCalculator.js
+++ b/chrome-extension/js/core/ByoyakuCalculator.js
@@ -28,6 +28,17 @@ const CONTROL_CYCLE = {
 // 五行リスト
 const ELEMENTS = ['木', '火', '土', '金', '水'];
 
+// 長養三方（R-01）。土は初版対象外
+const CHOUYOU_BRANCHES = {
+  木: ['寅', '卯', '辰'],
+  火: ['巳', '午', '未'],
+  金: ['申', '酉', '戌'],
+  水: ['亥', '子', '丑'],
+  土: []
+};
+
+const CONG_ZHONG_OU_RATIO = 0.40;
+
 // 十神 → 用神五行を得るための関係マッピング
 // 格局名から、その格局が「用いている」十神カテゴリを得る
 const KAKKYOKU_YOUSHIN_MAP = {
@@ -207,17 +218,29 @@ export class ByoyakuCalculator {
       strengthResult, kakkyokuResult, fourDiseaseResult, elementDist, dayElement
     );
 
+    const treatmentMode = fourMedicineResult.treatmentMode
+      ?? (fourDiseaseResult.type === '雕' ? '琢' : null);
+    const treatmentElements = fourMedicineResult.treatmentElements
+      || (treatmentMode === '琢' && fourMedicineResult.element
+        ? [fourMedicineResult.element]
+        : []);
+
     // ── 各診断ごとに薬の五行・所在を計算 ──
-    const diagnoses = specificDiagnoses.map(diag => {
+    let diagnoses = specificDiagnoses.map(diag => {
+      const diseaseElement = this._inferDiseaseElementFromTenGod(diag.diseaseTenGod, dayElement)
+        ?? fourDiseaseResult.diseaseElement
+        ?? null;
       const medicineElement = this._inferMedicineElement(diag.medicineTenGod, dayElement)
-        || fourMedicineResult.element;
+        || fourMedicineResult.element
+        || treatmentElements[0]
+        || null;
       const medicineLocation = this._findMedicineInChart(medicineElement, fortuneResult, transformedMap);
       return {
         role: 'primary',
         source: 'keizen',
         disease: {
           name: diag.diseaseName,
-          element: fourDiseaseResult.diseaseElement,
+          element: diseaseElement,
           tenGod: diag.diseaseTenGod,
           severity
         },
@@ -226,30 +249,51 @@ export class ByoyakuCalculator {
           element: medicineElement,
           tenGod: diag.medicineTenGod,
           exists: medicineLocation.exists,
-          location: medicineLocation.location
+          location: medicineLocation.location,
+          choukouAligned: false
         },
-        reason: diag.reason
+        reason: diag.reason,
+        fourDisease: fourDiseaseResult.type,
+        fourMedicine: fourMedicineResult.type,
+        treatmentMode
       };
     });
 
-    // 先頭要素で後方互換性を維持
-    const first = diagnoses[0];
+    // ── 調候 × 十神薬の突合（T-03d）──
+    diagnoses = diagnoses.map(diag => this._reconcileWithChoukou(diag, kishouResult));
+
+    // 気象が extreme かつ用神損傷が無いとき、気象診断を先頭へ
+    if (kishouResult?.isExtreme && (keizenResult.breaks || []).length === 0) {
+      diagnoses = [this._buildKishouDiagnosis(kishouResult), ...diagnoses];
+    } else if (kishouResult?.isExtreme) {
+      diagnoses = [...diagnoses, this._buildKishouDiagnosis(kishouResult)];
+    }
+
+    const balance = this._assessBalance(
+      diagnoses, fortuneResult, dayElement, fourDiseaseResult, keizenResult, kishouResult
+    );
+    const kiki = this._buildKiki(diagnoses);
+
+    // 代表診断: 用神損傷の primary を優先（表示先頭と分離）
+    const representative = diagnoses.find(d => d.source === 'keizen' && d.role === 'primary')
+      || diagnoses[0];
+    const choukouAligned = Boolean(representative?.medicine?.choukouAligned);
 
     return {
-      disease: first.disease,
-      medicine: first.medicine,
-      summary: first.reason,
+      disease: representative.disease,
+      medicine: representative.medicine,
+      summary: representative.reason,
       fourDisease: fourDiseaseResult.type,
       fourMedicine: fourMedicineResult.type,
       fourDiseaseElement: fourDiseaseResult.diseaseElement ?? null,
       fourMedicineElement: fourMedicineResult.element ?? null,
-      treatmentMode: fourDiseaseResult.type === '雕' ? '琢' : null,
-      treatmentElements: fourDiseaseResult.type === '雕' && fourMedicineResult.element
-        ? [fourMedicineResult.element]
-        : [],
+      treatmentMode,
+      treatmentElements,
       diagnoses,
       heaviestElement,
       heaviestRatio,
+      balance,
+      kiki,
       kishou: kishouResult,
       keizen: {
         pillar: keizenResult.pillar,
@@ -258,7 +302,7 @@ export class ByoyakuCalculator {
       },
       meta: {
         version: 'byoyaku-2.0',
-        choukouAligned: false,
+        choukouAligned,
         viaLegacyAdapter: Boolean(input._viaLegacyAdapter)
       }
     };
@@ -269,39 +313,49 @@ export class ByoyakuCalculator {
   // ═══════════════════════════════════════════════════════
 
   /**
-   * 命式全体の五行分布を加重計算する
-   * 天干=1.0, 蔵干主気=0.7, 蔵干中気=0.5, 蔵干余気=0.3
+   * 命式全体の五行分布を加重計算する（BYO-DD-02 / R-02）
+   *
+   * 年干・時干=1.0、月干=1.2、日干は除外。
+   * 蔵干=主0.7/中0.5/余0.3、月支主気のみ×2.0（寄与1.4）。
+   * 合化成功支は化後五行を主気相当で加算し、月支なら同じ×2.0。
    * @private
    */
   _calcElementDistribution(fortuneResult, transformedMap = null) {
     const dist = { '木': 0, '火': 0, '土': 0, '金': 0, '水': 0 };
-    const pillars = [
-      fortuneResult.yearPillar,
-      fortuneResult.monthPillar,
-      fortuneResult.dayPillar,
-      fortuneResult.hourPillar
+    const pillarSpecs = [
+      { key: 'yearPillar', stemWeight: 1.0, monthMainBoost: 1.0 },
+      { key: 'monthPillar', stemWeight: 1.2, monthMainBoost: 2.0 },
+      { key: 'dayPillar', stemWeight: 0, monthMainBoost: 1.0 },
+      { key: 'hourPillar', stemWeight: 1.0, monthMainBoost: 1.0 }
     ];
 
-    for (let i = 0; i < pillars.length; i++) {
-      const pillar = pillars[i];
+    for (let i = 0; i < pillarSpecs.length; i++) {
+      const { key, stemWeight, monthMainBoost } = pillarSpecs[i];
+      const pillar = fortuneResult[key];
       if (!pillar) continue;
-      // 天干
-      const stemEl = STEM_ELEMENTS[pillar.stem];
-      if (stemEl) dist[stemEl] += 1.0;
 
-      // 合化成功した地支は化後の五行で計算（主気相当の重み）
+      const stemEl = STEM_ELEMENTS[pillar.stem];
+      if (stemEl && stemWeight > 0) dist[stemEl] += stemWeight;
+
+      // 合化成功した地支は化後の五行を主気相当で計算
       if (transformedMap && transformedMap.has(i)) {
-        dist[transformedMap.get(i)] += 0.7;
+        dist[transformedMap.get(i)] += 0.7 * monthMainBoost;
         continue;
       }
 
-      // 蔵干（主気, 中気, 余気の順に重みを下げる）
-      const weights = [0.7, 0.5, 0.3];
       const hidden = pillar.hiddenStems || [];
-      for (let j = 0; j < hidden.length; j++) {
-        const el = STEM_ELEMENTS[hidden[j]];
-        if (el) dist[el] += (weights[j] || 0.3);
+      if (hidden.length > 0) {
+        const weights = [0.7 * monthMainBoost, 0.5, 0.3];
+        for (let j = 0; j < hidden.length; j++) {
+          const el = STEM_ELEMENTS[hidden[j]];
+          if (el) dist[el] += (weights[j] ?? 0.3);
+        }
+        continue;
       }
+
+      // 蔵干省略時は地支本気を主気として扱う
+      const branchEl = BRANCH_ELEMENTS[pillar.branch];
+      if (branchEl) dist[branchEl] += 0.7 * monthMainBoost;
     }
     return dist;
   }
@@ -329,11 +383,13 @@ export class ByoyakuCalculator {
   /**
    * 四病の分類
    *
-   * 判定優先順位:
-   *   1. 雕 — 用神に対する対立要素が命式中に全くない
-   *   2. 枯 — 用神の五行が弱いが蔵干に根がある（復活可能）
-   *   3. 旺 — ある五行が極端に強い（従重者論で突出）
-   *   4. 弱 — 日主または用神が不足
+   * 判定優先順位（R-01 / BYO-DD-05）:
+   *   1. 特殊格局 → 旺/弱
+   *   2. 旺（從重比率 ≥ 40%）
+   *   3. 雕
+   *   4. 枯
+   *   5. 旺（身旺スコア）
+   *   6. 弱（デフォルト）
    *
    * @private
    */
@@ -345,23 +401,27 @@ export class ByoyakuCalculator {
       return this._classifySpecialKakkyoku(strengthResult, dayElement, elementDist);
     }
 
-    // ── 1. 雕チェック ──
+    // ── 2. 從重40%は雕より先に旺 ──
+    const ouByRatio = this._checkOuByRatio(elementDist);
+    if (ouByRatio) return ouByRatio;
+
+    // ── 3. 雕チェック ──
     const choResult = this._checkCho(
       youshinCategory, tsuuhenList, dayElement, elementDist, fortuneResult, transformedMap
     );
     if (choResult) return choResult;
 
-    // ── 2. 枯チェック ──
+    // ── 4. 枯チェック ──
     const koResult = this._checkKo(
       youshinCategory, dayElement, elementDist, fortuneResult, transformedMap
     );
     if (koResult) return koResult;
 
-    // ── 3. 旺チェック ──
-    const ouResult = this._checkOu(dayElement, elementDist, strengthResult);
-    if (ouResult) return ouResult;
+    // ── 5. 身旺スコアによる旺 ──
+    const ouByStrength = this._checkOuByStrength(dayElement, strengthResult);
+    if (ouByStrength) return ouByStrength;
 
-    // ── 4. 弱（デフォルト） ──
+    // ── 6. 弱（デフォルト） ──
     return this._classifyJaku(dayElement, elementDist, strengthResult, youshinCategory);
   }
 
@@ -392,11 +452,11 @@ export class ByoyakuCalculator {
     const hasOppositionInHidden = this._hasElementInHiddenStems(oppositionElement, fortuneResult, transformedMap);
 
     if (!hasOpposition && !hasOppositionInHidden) {
-      // 雕の病: 対立要素が皆無
-      const youshinElement = this._getCategoryElement(youshinCategory, dayElement);
+      // 雕: 害神五行は存在しない（fourDiseaseElement=null）。磨く側は treatmentElements
       return {
         type: '雕',
-        diseaseElement: youshinElement,
+        diseaseElement: null,
+        treatmentElements: oppositionElement ? [oppositionElement] : [],
         description: this._getChoDescription(youshinCategory),
         heaviestElement: null
       };
@@ -450,18 +510,13 @@ export class ByoyakuCalculator {
   }
 
   /**
-   * 旺（過旺）のチェック
-   *
-   * 命式中のある五行が極端に強い
-   * 従重者論: 最も重い五行が全体の40%以上を占める場合
-   *
+   * 從重比率による旺（≥40%）
    * @private
    */
-  _checkOu(dayElement, elementDist, strengthResult) {
+  _checkOuByRatio(elementDist) {
     const total = Object.values(elementDist).reduce((a, b) => a + b, 0);
     if (total === 0) return null;
 
-    // 各五行の比率を計算し、突出したものを探す
     let maxEl = null;
     let maxRatio = 0;
     for (const el of ELEMENTS) {
@@ -472,8 +527,7 @@ export class ByoyakuCalculator {
       }
     }
 
-    // 40%以上を占める五行があれば「旺の病」
-    if (maxRatio >= 0.40) {
+    if (maxRatio >= CONG_ZHONG_OU_RATIO) {
       return {
         type: '旺',
         diseaseElement: maxEl,
@@ -481,8 +535,14 @@ export class ByoyakuCalculator {
         heaviestElement: maxEl
       };
     }
+    return null;
+  }
 
-    // 身旺（スコア高い）でも旺と判定
+  /**
+   * 身旺スコアによる旺
+   * @private
+   */
+  _checkOuByStrength(dayElement, strengthResult) {
     if (strengthResult.strength === 'strong' && strengthResult.score >= 4) {
       return {
         type: '旺',
@@ -491,7 +551,6 @@ export class ByoyakuCalculator {
         heaviestElement: dayElement
       };
     }
-
     return null;
   }
 
@@ -550,67 +609,74 @@ export class ByoyakuCalculator {
   // ═══════════════════════════════════════════════════════
 
   /**
-   * 四薬を処方する
+   * 四薬を処方する（R-01 v1.1）
    *
-   * - 旺 → 損（過剰な五行を剋で制す）
-   * - 弱 → 益（不足を生・同類で補う）
-   * - 枯 → 生/長（根元を養い復活させる）
-   * - 雕 → 対立要素を導入して磨く（損に近いが性質が異なる）
+   * - 旺＋長養 → 長（克）。それ以外の旺 → 損
+   * - 弱 → 益
+   * - 枯 → 生（滋養）
+   * - 雕 → fourMedicine=null、treatmentMode=琢
    *
    * @private
    */
   _classifyFourMedicine(fourDiseaseResult, dayElement, elementDist, fortuneResult, youshinCategory) {
     const diseaseType = fourDiseaseResult.type;
     const diseaseElement = fourDiseaseResult.diseaseElement;
+    const monthBranch = fortuneResult?.monthPillar?.branch || null;
 
     switch (diseaseType) {
       case '旺': {
-        // 損: 過剰な五行を剋する五行が薬
         const controllingEl = this._getElementThatControls(diseaseElement);
-        // 特例: 日主が旺で洩気の方が有効な場合もある
-        // 食傷で洩らすか、官殺で制すかは具体的ルールに委ねる
-        return { type: '損', element: controllingEl };
+        const stage = this._resolveElementStage(diseaseElement, monthBranch);
+        if (stage === '長養') {
+          return { type: '長', element: controllingEl, stage };
+        }
+        return { type: '損', element: controllingEl, stage };
       }
 
       case '弱': {
-        // 益: 弱い五行を生じる五行 or 同類で補う
         if (diseaseElement === dayElement) {
-          // 日主が弱い → 印星（生じる五行）で補う
           const generatingEl = this._getElementThatGenerates(dayElement);
           return { type: '益', element: generatingEl };
-        } else {
-          // 用神が弱い → 用神を生じる五行 or 用神の同類
-          const generatingEl = this._getElementThatGenerates(diseaseElement);
-          return { type: '益', element: generatingEl || diseaseElement };
         }
+        const generatingEl = this._getElementThatGenerates(diseaseElement);
+        return { type: '益', element: generatingEl || diseaseElement };
       }
 
       case '枯': {
-        // 生/長: 枯渇した五行の根元を養う
-        // 用神を生じる五行が「生の薬」
-        // 蔵干に根があるので通関で気を回す
         const generatingEl = this._getElementThatGenerates(diseaseElement);
-        // 長生・沐浴の段階 → 生, 冠帯以降 → 長
-        // 簡易判定: 根はあるがまだ弱い → 「生」
         return { type: '生', element: generatingEl };
       }
 
       case '雕': {
-        // 対立要素を導入して磨く
-        // 用神の対立十神カテゴリの五行が薬
         const oppositionCategory = youshinCategory ? OPPOSITION_MAP[youshinCategory] : null;
-        if (oppositionCategory) {
-          const oppositionEl = this._getCategoryElement(oppositionCategory, dayElement);
-          return { type: '損', element: oppositionEl };
-        }
-        // フォールバック
-        const controllingEl = this._getElementThatControls(diseaseElement);
-        return { type: '損', element: controllingEl };
+        const oppositionEl = oppositionCategory
+          ? this._getCategoryElement(oppositionCategory, dayElement)
+          : null;
+        const treatmentElements = fourDiseaseResult.treatmentElements?.length
+          ? fourDiseaseResult.treatmentElements
+          : (oppositionEl ? [oppositionEl] : []);
+        return {
+          type: null,
+          element: null,
+          treatmentMode: '琢',
+          treatmentElements
+        };
       }
 
       default:
         return { type: '益', element: this._getElementThatGenerates(dayElement) };
     }
+  }
+
+  /**
+   * 対象五行の勢い段階（長養 / その他）。土は初版対象外。
+   * @private
+   */
+  _resolveElementStage(element, monthBranch) {
+    if (!element || !monthBranch || element === '土') return 'その他';
+    const branches = CHOUYOU_BRANCHES[element] || [];
+    if (branches.includes(monthBranch)) return '長養';
+    return 'その他';
   }
 
   // ═══════════════════════════════════════════════════════
@@ -970,6 +1036,214 @@ export class ByoyakuCalculator {
       default:
         return null;
     }
+  }
+
+  /** 病の十神から五行を逆算する */
+  _inferDiseaseElementFromTenGod(diseaseTenGod, dayElement) {
+    return this._inferMedicineElement(diseaseTenGod, dayElement);
+  }
+
+  /**
+   * 十神薬と調候の突合（T-03d）
+   * @private
+   */
+  _reconcileWithChoukou(diag, kishouResult) {
+    const choukou = kishouResult?.choukou;
+    if (!choukou || choukou.direction === 'なし') {
+      return diag;
+    }
+
+    const choukouEls = choukou.primaryElements || [];
+    const medEl = diag.medicine?.element;
+    const aligned = Boolean(medEl && choukouEls.includes(medEl));
+
+    const next = {
+      ...diag,
+      medicine: {
+        ...diag.medicine,
+        choukouAligned: aligned
+      }
+    };
+
+    if (!aligned && choukouEls.length > 0) {
+      next.medicineSecondary = {
+        name: `調候（${choukou.direction}）`,
+        element: choukouEls[0],
+        elements: choukouEls,
+        tenGod: null,
+        exists: false,
+        location: null,
+        choukouAligned: true
+      };
+      next.reason = `${diag.reason}（主軸の薬と調候を併記）`;
+    } else if (aligned) {
+      next.reason = `${diag.reason}（格局薬と調候が一致）`;
+    }
+
+    return next;
+  }
+
+  /**
+   * 気象診断アイテムを生成
+   * @private
+   */
+  _buildKishouDiagnosis(kishouResult) {
+    const direction = kishouResult.choukou?.direction || 'なし';
+    const elements = kishouResult.choukou?.primaryElements || [];
+    return {
+      role: 'secondary',
+      source: 'kishou',
+      disease: {
+        name: `気象偏枯（${kishouResult.temperature}/${kishouResult.humidity}）`,
+        element: null,
+        causeElements: kishouResult.causeElements || [],
+        deficientElements: kishouResult.deficientElements || elements,
+        tenGod: null,
+        severity: kishouResult.severity || 'moderate'
+      },
+      medicine: {
+        name: `調候（${direction}）`,
+        element: elements[0] || null,
+        elements,
+        tenGod: null,
+        exists: false,
+        location: null,
+        choukouAligned: true
+      },
+      reason: kishouResult.summary || '気象の偏りを調候で整える',
+      fourDisease: null,
+      fourMedicine: null,
+      treatmentMode: null
+    };
+  }
+
+  /**
+   * 病薬バランス（0-3）
+   * @private
+   */
+  _assessBalance(diagnoses, fortuneResult, dayElement, fourDiseaseResult, keizenResult, kishouResult) {
+    const primary = diagnoses.find(d => d.source === 'keizen') || diagnoses[0];
+    if (!primary) {
+      return {
+        label: '病なし薬なし',
+        diseaseScore: 0,
+        medicineScore: 0,
+        reading: '目立った病薬なし'
+      };
+    }
+
+    const noBreaks = (keizenResult?.breaks || []).length === 0;
+    const mildKishou = !kishouResult?.isExtreme;
+    if (
+      (fourDiseaseResult.type === '雕' || noBreaks) &&
+      mildKishou &&
+      fourDiseaseResult.type !== '旺' &&
+      fourDiseaseResult.type !== '弱' &&
+      fourDiseaseResult.type !== '枯'
+    ) {
+      // 雕のみ・気象も穏やか → 病なし寄り
+      if (fourDiseaseResult.type === '雕' && noBreaks) {
+        return {
+          label: '病なし薬なし',
+          diseaseScore: 0,
+          medicineScore: 0,
+          reading: '用神は純だが、当面の破は軽い'
+        };
+      }
+    }
+
+    let diseaseScore = 0;
+    const sev = primary.disease?.severity;
+    if (sev === 'severe') diseaseScore += 2;
+    else if (sev === 'moderate') diseaseScore += 1;
+
+    const diseaseEl = primary.disease?.element;
+    const monthBranchEl = BRANCH_ELEMENTS[fortuneResult.monthPillar?.branch];
+    if (diseaseEl && diseaseEl === monthBranchEl) diseaseScore += 1;
+
+    const stems = [
+      fortuneResult.yearPillar?.stem,
+      fortuneResult.monthPillar?.stem,
+      fortuneResult.hourPillar?.stem
+    ].filter(Boolean);
+    if (diseaseEl) {
+      const stemHits = stems.filter(s => STEM_ELEMENTS[s] === diseaseEl).length;
+      if (stemHits >= 2) diseaseScore += 1;
+      if (this._hasElementInHiddenStems(diseaseEl, fortuneResult)) diseaseScore += 1;
+    }
+    diseaseScore = Math.min(3, diseaseScore);
+
+    let medicineScore = 0;
+    const med = primary.medicine || {};
+    if (med.exists && med.location && String(med.location).includes('干')) medicineScore += 2;
+    else if (med.exists) medicineScore += 1;
+    if (med.element && med.element === monthBranchEl) medicineScore += 1;
+    if (med.choukouAligned) medicineScore += 1;
+    medicineScore = Math.min(3, medicineScore);
+
+    let label;
+    if (diseaseScore >= 2 && medicineScore >= 2) label = '病重薬重';
+    else if (diseaseScore >= 2 && medicineScore <= 1) label = '病重薬軽';
+    else if (diseaseScore <= 1 && medicineScore >= 2) label = '病軽薬重';
+    else label = '病軽薬軽';
+
+    return {
+      label,
+      diseaseScore,
+      medicineScore,
+      reading: `病力${diseaseScore}/薬力${medicineScore}（${label}）`
+    };
+  }
+
+  /**
+   * 喜忌ラベル
+   * @private
+   */
+  _buildKiki(diagnoses) {
+    const ki = [];
+    const ji = [];
+    const seenKi = new Set();
+    const seenJi = new Set();
+
+    for (const diag of diagnoses) {
+      if (diag.medicine?.element || diag.medicine?.tenGod) {
+        const key = `${diag.medicine.tenGod || ''}:${diag.medicine.element || ''}`;
+        if (!seenKi.has(key)) {
+          seenKi.add(key);
+          ki.push({
+            label: diag.medicine.name,
+            element: diag.medicine.element || undefined,
+            tenGod: diag.medicine.tenGod || undefined
+          });
+        }
+      }
+      if (diag.medicineSecondary?.elements) {
+        for (const el of diag.medicineSecondary.elements) {
+          const key = `choukou:${el}`;
+          if (!seenKi.has(key)) {
+            seenKi.add(key);
+            ki.push({ label: diag.medicineSecondary.name, element: el });
+          }
+        }
+      }
+      if (diag.disease?.element || diag.disease?.tenGod) {
+        const key = `${diag.disease.tenGod || ''}:${diag.disease.element || ''}`;
+        if (!seenJi.has(key)) {
+          seenJi.add(key);
+          ji.push({
+            label: diag.disease.name,
+            element: diag.disease.element || undefined,
+            tenGod: diag.disease.tenGod || undefined
+          });
+        }
+      }
+    }
+
+    return {
+      ki,
+      ji,
+      note: '薬側を喜、病側を忌とする（役割ラベル）'
+    };
   }
 }
 

--- a/chrome-extension/js/core/ByoyakuCalculator.js
+++ b/chrome-extension/js/core/ByoyakuCalculator.js
@@ -164,7 +164,8 @@ export class ByoyakuCalculator {
       keizenResult
     } = input;
 
-    if (!kakkyokuResult || !strengthResult || !fortuneResult) {
+    if (!kakkyokuResult || !strengthResult || !fortuneResult || !tsuuhenResult
+      || !fortuneResult.dayPillar?.stem) {
       throw new CalculationError('病薬判定に必要なデータが不足しています');
     }
     if (!kishouResult) {
@@ -208,10 +209,14 @@ export class ByoyakuCalculator {
     );
 
     // ── 格局固有ルールで具体的病薬名を取得（複数マッチ） ──
-    const specificDiagnoses = this._getSpecificDiagnosis(
-      kakkyokuResult, strengthResult, fortuneResult, tsuuhenResult,
-      dayElement, tsuuhenList, transformedMap
-    );
+    const specificDiagnoses = input._viaLegacyAdapter
+      ? this._getSpecificDiagnosis(
+        kakkyokuResult, strengthResult, fortuneResult, tsuuhenResult,
+        dayElement, tsuuhenList, transformedMap
+      )
+      : this._getSpecificDiagnosisFromBreaks(
+        kakkyokuResult, strengthResult, dayElement, keizenResult
+      );
 
     // ── 重症度判定 ──
     const severity = this._assessSeverity(
@@ -227,7 +232,8 @@ export class ByoyakuCalculator {
 
     // ── 各診断ごとに薬の五行・所在を計算 ──
     let diagnoses = specificDiagnoses.map(diag => {
-      const diseaseElement = this._inferDiseaseElementFromTenGod(diag.diseaseTenGod, dayElement)
+      const diseaseElement = diag.diseaseElement
+        ?? this._inferDiseaseElementFromTenGod(diag.diseaseTenGod, dayElement)
         ?? fourDiseaseResult.diseaseElement
         ?? null;
       const medicineElement = this._inferMedicineElement(diag.medicineTenGod, dayElement)
@@ -242,7 +248,7 @@ export class ByoyakuCalculator {
           name: diag.diseaseName,
           element: diseaseElement,
           tenGod: diag.diseaseTenGod,
-          severity
+          severity: diag.severityHint || severity
         },
         medicine: {
           name: diag.medicineName,
@@ -260,17 +266,26 @@ export class ByoyakuCalculator {
     });
 
     // ── 調候 × 十神薬の突合（T-03d）──
-    diagnoses = diagnoses.map(diag => this._reconcileWithChoukou(diag, kishouResult));
+    diagnoses = diagnoses.map(diag => this._reconcileWithChoukou(
+      diag, kishouResult, fortuneResult, transformedMap
+    ));
 
     // 気象が extreme かつ用神損傷が無いとき、気象診断を先頭へ
     if (kishouResult?.isExtreme && (keizenResult.breaks || []).length === 0) {
-      diagnoses = [this._buildKishouDiagnosis(kishouResult), ...diagnoses];
+      diagnoses = [
+        this._buildKishouDiagnosis(kishouResult, fortuneResult, transformedMap),
+        ...diagnoses
+      ];
     } else if (kishouResult?.isExtreme) {
-      diagnoses = [...diagnoses, this._buildKishouDiagnosis(kishouResult)];
+      diagnoses = [
+        ...diagnoses,
+        this._buildKishouDiagnosis(kishouResult, fortuneResult, transformedMap)
+      ];
     }
 
     const balance = this._assessBalance(
-      diagnoses, fortuneResult, dayElement, fourDiseaseResult, keizenResult, kishouResult
+      diagnoses, fortuneResult, dayElement, fourDiseaseResult, keizenResult,
+      kishouResult, transformedMap
     );
     const kiki = this._buildKiki(diagnoses);
 
@@ -729,6 +744,63 @@ export class ByoyakuCalculator {
   }
 
   /**
+   * KeizenAnalyzer の breaks を正として具体診断へ変換する（v2 API）。
+   * ルールに無い break も捨てず、BreakItem の内容から診断を生成する。
+   * @private
+   */
+  _getSpecificDiagnosisFromBreaks(kakkyokuResult, strengthResult, dayElement, keizenResult) {
+    const kakkyokuRule = this.rules[kakkyokuResult.kakkyoku];
+    const defaultStrengthKey = strengthResult.strength === 'weak' ? 'weak' : 'strong';
+    const breaks = keizenResult?.breaks || [];
+
+    if (breaks.length === 0) {
+      const defaultDisease = kakkyokuRule?.[defaultStrengthKey]?.defaultDisease;
+      if (!defaultDisease) {
+        return [this._createFallbackDiagnosis(strengthResult, dayElement)];
+      }
+      return [this._normalizeSpecificDiagnosis(defaultDisease, dayElement)];
+    }
+
+    return breaks.map(breakItem => {
+      const strengthKey = ['strong', 'weak'].includes(breakItem.strengthSide)
+        ? breakItem.strengthSide
+        : defaultStrengthKey;
+      const matchedRule = kakkyokuRule?.[strengthKey]?.diseases
+        ?.find(rule => rule.condition === breakItem.condition);
+
+      if (matchedRule) {
+        return this._normalizeSpecificDiagnosis(matchedRule, dayElement, breakItem);
+      }
+
+      const medicineName = breakItem.medicineHint || '薬方向を要検討';
+      return {
+        diseaseName: breakItem.name || breakItem.condition || '用神損傷',
+        medicineName,
+        reason: breakItem.reason || `${breakItem.name || '用神'}の損傷を確認`,
+        diseaseTenGod: breakItem.diseaseTenGod
+          ?? this._inferDiseaseTenGod(breakItem.name || '', dayElement),
+        diseaseElement: breakItem.diseaseElement ?? null,
+        medicineTenGod: this._inferMedicineTenGod(medicineName, dayElement),
+        severityHint: breakItem.severityHint || null
+      };
+    });
+  }
+
+  /** @private */
+  _normalizeSpecificDiagnosis(rule, dayElement, breakItem = null) {
+    return {
+      diseaseName: rule.disease,
+      medicineName: rule.medicine,
+      reason: rule.reason,
+      diseaseTenGod: breakItem?.diseaseTenGod
+        ?? this._inferDiseaseTenGod(rule.disease, dayElement),
+      diseaseElement: breakItem?.diseaseElement ?? null,
+      medicineTenGod: this._inferMedicineTenGod(rule.medicine, dayElement),
+      severityHint: breakItem?.severityHint || null
+    };
+  }
+
+  /**
    * ルールにない場合のフォールバック
    * @private
    */
@@ -1047,7 +1119,7 @@ export class ByoyakuCalculator {
    * 十神薬と調候の突合（T-03d）
    * @private
    */
-  _reconcileWithChoukou(diag, kishouResult) {
+  _reconcileWithChoukou(diag, kishouResult, fortuneResult, transformedMap = null) {
     const choukou = kishouResult?.choukou;
     if (!choukou || choukou.direction === 'なし') {
       return diag;
@@ -1066,13 +1138,16 @@ export class ByoyakuCalculator {
     };
 
     if (!aligned && choukouEls.length > 0) {
+      const location = this._findMedicineInChart(
+        choukouEls[0], fortuneResult, transformedMap
+      );
       next.medicineSecondary = {
         name: `調候（${choukou.direction}）`,
         element: choukouEls[0],
         elements: choukouEls,
         tenGod: null,
-        exists: false,
-        location: null,
+        exists: location.exists,
+        location: location.location,
         choukouAligned: true
       };
       next.reason = `${diag.reason}（主軸の薬と調候を併記）`;
@@ -1087,9 +1162,12 @@ export class ByoyakuCalculator {
    * 気象診断アイテムを生成
    * @private
    */
-  _buildKishouDiagnosis(kishouResult) {
+  _buildKishouDiagnosis(kishouResult, fortuneResult, transformedMap = null) {
     const direction = kishouResult.choukou?.direction || 'なし';
     const elements = kishouResult.choukou?.primaryElements || [];
+    const location = this._findMedicineInChart(
+      elements[0] || null, fortuneResult, transformedMap
+    );
     return {
       role: 'secondary',
       source: 'kishou',
@@ -1106,8 +1184,8 @@ export class ByoyakuCalculator {
         element: elements[0] || null,
         elements,
         tenGod: null,
-        exists: false,
-        location: null,
+        exists: location.exists,
+        location: location.location,
         choukouAligned: true
       },
       reason: kishouResult.summary || '気象の偏りを調候で整える',
@@ -1121,7 +1199,8 @@ export class ByoyakuCalculator {
    * 病薬バランス（0-3）
    * @private
    */
-  _assessBalance(diagnoses, fortuneResult, dayElement, fourDiseaseResult, keizenResult, kishouResult) {
+  _assessBalance(diagnoses, fortuneResult, dayElement, fourDiseaseResult,
+                 keizenResult, kishouResult, transformedMap = null) {
     const primary = diagnoses.find(d => d.source === 'keizen') || diagnoses[0];
     if (!primary) {
       return {
@@ -1169,7 +1248,9 @@ export class ByoyakuCalculator {
     if (diseaseEl) {
       const stemHits = stems.filter(s => STEM_ELEMENTS[s] === diseaseEl).length;
       if (stemHits >= 2) diseaseScore += 1;
-      if (this._hasElementInHiddenStems(diseaseEl, fortuneResult)) diseaseScore += 1;
+      if (this._hasElementInHiddenStems(diseaseEl, fortuneResult, transformedMap)) {
+        diseaseScore += 1;
+      }
     }
     diseaseScore = Math.min(3, diseaseScore);
 

--- a/chrome-extension/js/core/DaiunHyoukaCalculator.js
+++ b/chrome-extension/js/core/DaiunHyoukaCalculator.js
@@ -58,13 +58,20 @@ export class DaiunHyoukaCalculator {
 
     const dayStem = fortuneResult.dayPillar.stem;
 
-    // 薬・病の五行を収集
-    const medicineElements = [...new Set(
-      byoyakuResult.diagnoses
-        .map(d => d.medicine.element)
-        .filter(Boolean)
-    )];
-    const diseaseElement = byoyakuResult.diagnoses[0]?.disease.element || null;
+    // 後方互換APIの代表診断を正とする。表示先頭は気象診断の場合があるため、
+    // diagnoses[0] から病五行を取らない（BYO-DD-06 / AC-05）。
+    const primaryDiagnosis = byoyakuResult.diagnoses
+      ?.find(d => d.role === 'primary') || byoyakuResult.diagnoses?.[0] || null;
+    const medicineElement = byoyakuResult.medicine
+      ? byoyakuResult.medicine.element
+      : primaryDiagnosis?.medicine?.element;
+    const diseaseElement = byoyakuResult.disease
+      ? byoyakuResult.disease.element
+      : primaryDiagnosis?.disease?.element;
+    const medicineElements = medicineElement ? [medicineElement] : [];
+
+    // 代表病・代表薬とも五行が無ければ吉凶評価を行わない。
+    if (!diseaseElement && medicineElements.length === 0) return [];
 
     return cycles.map(cycle => {
       const stemElement = STEM_ELEMENTS[cycle.stem];

--- a/chrome-extension/tests/core/ByoyakuCalculator.test.js
+++ b/chrome-extension/tests/core/ByoyakuCalculator.test.js
@@ -571,6 +571,124 @@ test('ByoyakuCalculator - 調候不一致なら medicineSecondary を併記', ()
     assert.strictEqual(result.disease.name, '比劫奪官', '代表病は用神損傷側');
 });
 
+test('ByoyakuCalculator - v2はKeizen breaksを具体診断の正とする', () => {
+    const fortuneResult = {
+        yearPillar:  { stem: '庚', branch: '申', hiddenStems: ['庚', '壬', '戊'] },
+        monthPillar: { stem: '己', branch: '未', hiddenStems: ['己', '丁', '乙'] },
+        dayPillar:   { stem: '戊', branch: '辰', hiddenStems: ['戊', '乙', '癸'] },
+        hourPillar:  { stem: '甲', branch: '寅', hiddenStems: ['甲', '丙', '戊'] }
+    };
+    // 命式からの旧condition再計算では比劫多にならない入力にする。
+    const tsuuhenResult = {
+        year: { tsuuhen: '食神' },
+        month: { tsuuhen: '劫財' },
+        hour: { tsuuhen: '偏官' }
+    };
+    const result = calculator.diagnose({
+        kakkyokuResult: { kakkyoku: '正財格', category: 'regular', isEstablished: false },
+        strengthResult: { strength: 'strong', score: 5 },
+        fortuneResult,
+        tsuuhenResult,
+        kishouResult: {
+            temperature: '中和', humidity: '中', severity: 'mild', isExtreme: false,
+            choukou: { direction: 'なし', primaryElements: [], secondary: [] }
+        },
+        keizenResult: {
+            pillar: { kakkyoku: '正財格', youshinCategory: 'wealth', isEstablished: false },
+            breaks: [{
+                condition: '比劫多', name: '比劫奪財', diseaseTenGod: '比肩',
+                diseaseElement: '土', severityHint: 'severe', medicineHint: '官殺',
+                reason: 'Keizenで検出', strengthSide: 'strong'
+            }],
+            summary: '比劫奪財'
+        }
+    });
+
+    assert.strictEqual(result.diagnoses[0].disease.name, '比劫奪財');
+    assert.strictEqual(result.diagnoses[0].disease.element, '土');
+    assert.strictEqual(result.diagnoses[0].disease.severity, 'severe');
+    assert.strictEqual(result.diagnoses.length, 1, '再計算した別conditionを混入しない');
+});
+
+test('ByoyakuCalculator - ルール外のKeizen breakも診断から捨てない', () => {
+    const fortuneResult = {
+        yearPillar:  { stem: '甲', branch: '寅', hiddenStems: ['甲', '丙', '戊'] },
+        monthPillar: { stem: '辛', branch: '酉', hiddenStems: ['辛'] },
+        dayPillar:   { stem: '甲', branch: '子', hiddenStems: ['癸'] },
+        hourPillar:  { stem: '丙', branch: '午', hiddenStems: ['丁', '己'] }
+    };
+    const result = calculator.diagnose({
+        kakkyokuResult: { kakkyoku: '正官格', category: 'regular', isEstablished: false },
+        strengthResult: { strength: 'weak', score: 0 },
+        fortuneResult,
+        tsuuhenResult: {
+            year: { tsuuhen: '比肩' }, month: { tsuuhen: '正官' }, hour: { tsuuhen: '食神' }
+        },
+        kishouResult: {
+            temperature: '中和', humidity: '中', severity: 'mild', isExtreme: false,
+            choukou: { direction: 'なし', primaryElements: [], secondary: [] }
+        },
+        keizenResult: {
+            pillar: { kakkyoku: '正官格', youshinCategory: 'officer', isEstablished: false },
+            breaks: [{
+                condition: '独自損傷', name: '独自の破', diseaseElement: '火',
+                severityHint: 'moderate', medicineHint: '印星', reason: '独自ルール'
+            }],
+            summary: '独自の破'
+        }
+    });
+
+    assert.strictEqual(result.diagnoses[0].disease.name, '独自の破');
+    assert.strictEqual(result.diagnoses[0].disease.element, '火');
+    assert.strictEqual(result.diagnoses[0].medicine.name, '印星');
+    assert.strictEqual(result.diagnoses[0].reason, '独自ルール');
+});
+
+test('ByoyakuCalculator - 從重40%の境界をfixtureどおり判定', () => {
+    const distribution = ratio => ({
+        木: ratio,
+        火: (1 - ratio) / 4,
+        土: (1 - ratio) / 4,
+        金: (1 - ratio) / 4,
+        水: (1 - ratio) / 4
+    });
+
+    assert.strictEqual(calculator._checkOuByRatio(distribution(0.399)), null, '0.399は旺にしない');
+    assert.strictEqual(calculator._checkOuByRatio(distribution(0.4)).type, '旺', '0.4は旺');
+    assert.strictEqual(calculator._checkOuByRatio(distribution(0.401)).type, '旺', '0.401は旺');
+});
+
+test('ByoyakuCalculator - 調候副薬の命式内所在を返す', () => {
+    const fortuneResult = {
+        yearPillar:  { stem: '丙', branch: '午', hiddenStems: ['丁', '己'] },
+        monthPillar: { stem: '辛', branch: '酉', hiddenStems: ['辛'] },
+        dayPillar:   { stem: '甲', branch: '子', hiddenStems: ['癸'] },
+        hourPillar:  { stem: '甲', branch: '寅', hiddenStems: ['甲', '丙', '戊'] }
+    };
+    const result = calculator.diagnose({
+        kakkyokuResult: { kakkyoku: '正官格', category: 'regular', isEstablished: true },
+        strengthResult: { strength: 'strong', score: 5 },
+        fortuneResult,
+        tsuuhenResult: {
+            year: { tsuuhen: '食神' }, month: { tsuuhen: '正官' }, hour: { tsuuhen: '比肩' }
+        },
+        kishouResult: {
+            temperature: '寒', humidity: '中', severity: 'moderate', isExtreme: true,
+            choukou: { direction: '温める', primaryElements: ['火'], secondary: [] },
+            causeElements: ['水'], deficientElements: ['火']
+        },
+        keizenResult: {
+            pillar: { kakkyoku: '正官格', youshinCategory: 'officer', isEstablished: true },
+            breaks: [{ condition: '比劫多', name: '比劫奪官', strengthSide: 'strong' }],
+            summary: '比劫奪官'
+        }
+    });
+
+    const primary = result.diagnoses.find(d => d.source === 'keizen');
+    assert.strictEqual(primary.medicineSecondary.exists, true);
+    assert.strictEqual(primary.medicineSecondary.location, '年干');
+});
+
 test('ByoyakuCalculator - diagnose v2 は kishou/keizen 必須', () => {
     const base = {
         kakkyokuResult: { kakkyoku: '正官格', isEstablished: true },
@@ -591,5 +709,14 @@ test('ByoyakuCalculator - diagnose v2 は kishou/keizen 必須', () => {
     assert.throws(
         () => calculator.diagnose({ ...base, kishouResult: { clarity: '不明' } }),
         'keizenResult は必須です'
+    );
+    assert.throws(
+        () => calculator.diagnose({
+            ...base,
+            tsuuhenResult: null,
+            kishouResult: { clarity: '不明' },
+            keizenResult: { pillar: {}, breaks: [] }
+        }),
+        '病薬判定に必要なデータが不足しています'
     );
 });

--- a/chrome-extension/tests/core/ByoyakuCalculator.test.js
+++ b/chrome-extension/tests/core/ByoyakuCalculator.test.js
@@ -323,9 +323,80 @@ test('ByoyakuCalculator - 結果構造の検証', () => {
 
     assert.ok(result.summary, 'サマリーがある');
     assert.ok(result.fourDisease, '四病分類がある');
-    assert.ok(result.fourMedicine, '四薬分類がある');
+    assert.ok('fourMedicine' in result, '四薬フィールドがある（雕ではnull可）');
 });
 
+test('ByoyakuCalculator - 月令主気ブースト（0.7×2.0）を分布に反映', () => {
+    const fortuneResult = {
+        yearPillar:  { stem: '甲', branch: '子', hiddenStems: ['癸'] },
+        monthPillar: { stem: '乙', branch: '卯', hiddenStems: ['乙'] },
+        dayPillar:   { stem: '庚', branch: '辰', hiddenStems: ['戊', '乙', '癸'] },
+        hourPillar:  { stem: '辛', branch: '酉', hiddenStems: ['辛'] }
+    };
+    const dist = calculator._calcElementDistribution(fortuneResult);
+    // 月支卯の主気乙=木が 0.7×2.0=1.4、月干乙=1.2 → 木 ≥ 2.6
+    assert.ok(dist['木'] >= 2.6, `月令木の寄与が十分: ${dist['木']}`);
+    // 日干庚は分布除外
+    assert.ok(dist['金'] < 3, '日干除外により金が過大にならない');
+});
+
+test('ByoyakuCalculator - 旺かつ長養月は四薬が長', () => {
+    const kakkyokuResult = {
+        kakkyoku: '偏官格',
+        category: 'regular',
+        isEstablished: true,
+        breakReason: null
+    };
+    const strengthResult = { strength: 'strong', score: 5 };
+    // 甲木日主・卯月。木を過重にして從重旺＋長養
+    const fortuneResult = {
+        yearPillar:  { stem: '甲', branch: '寅', hiddenStems: ['甲', '丙', '戊'] },
+        monthPillar: { stem: '乙', branch: '卯', hiddenStems: ['乙'] },
+        dayPillar:   { stem: '甲', branch: '寅', hiddenStems: ['甲', '丙', '戊'] },
+        hourPillar:  { stem: '甲', branch: '卯', hiddenStems: ['乙'] }
+    };
+    const tsuuhenResult = {
+        year:  { tsuuhen: '比肩' },
+        month: { tsuuhen: '劫財' },
+        hour:  { tsuuhen: '比肩' }
+    };
+
+    const result = calculator.diagnose(kakkyokuResult, strengthResult, fortuneResult, tsuuhenResult);
+    assert.strictEqual(result.fourDisease, '旺');
+    assert.strictEqual(result.fourDiseaseElement, '木');
+    assert.strictEqual(result.fourMedicine, '長', '長養の旺は長');
+    assert.strictEqual(result.fourMedicineElement, '金', '木の長薬は金');
+});
+
+test('ByoyakuCalculator - 雕は四薬nullで処置ラベル琢', () => {
+    const kakkyokuResult = {
+        kakkyoku: '偏印格',
+        category: 'regular',
+        isEstablished: true,
+        breakReason: null
+    };
+    // 從重40%と身旺スコア旺を避け、印あり・財(金)なしで雕を成立させる
+    const strengthResult = { strength: 'neutral', score: 2 };
+    const fortuneResult = {
+        yearPillar:  { stem: '甲', branch: '子', hiddenStems: ['癸'] },
+        monthPillar: { stem: '乙', branch: '亥', hiddenStems: ['壬', '甲'] },
+        dayPillar:   { stem: '丙', branch: '午', hiddenStems: ['丁', '己'] },
+        hourPillar:  { stem: '丁', branch: '午', hiddenStems: ['丁', '己'] }
+    };
+    // 印あり。丙の財=金が透蔵ともに無し
+    const tsuuhenResult = {
+        year:  { tsuuhen: '偏印' },
+        month: { tsuuhen: '正印' },
+        hour:  { tsuuhen: '劫財' }
+    };
+
+    const result = calculator.diagnose(kakkyokuResult, strengthResult, fortuneResult, tsuuhenResult);
+    assert.strictEqual(result.fourDisease, '雕');
+    assert.strictEqual(result.fourDiseaseElement, null);
+    assert.strictEqual(result.fourMedicine, null);
+    assert.strictEqual(result.treatmentMode, '琢');
+    assert.ok(result.treatmentElements.includes('金'), '丙の対立・財は金');
+});
 test('ByoyakuCalculator - diagnose v2 object API', () => {
     const kakkyokuResult = {
         kakkyoku: '正官格',
@@ -382,6 +453,122 @@ test('ByoyakuCalculator - diagnose v2 object API', () => {
     assert.strictEqual(result.keizen.pillar.youshinCategory, 'officer');
     assert.ok(result.heaviestElement, 'heaviestElement がある');
     assert.ok(typeof result.heaviestRatio === 'number');
+});
+
+test('ByoyakuCalculator - 調候一致で choukouAligned と balance を返す', () => {
+    const kakkyokuResult = {
+        kakkyoku: '正官格',
+        category: 'regular',
+        isEstablished: true,
+        breakReason: null
+    };
+    const strengthResult = { strength: 'strong', score: 5 };
+    const fortuneResult = {
+        yearPillar:  { stem: '甲', branch: '寅', hiddenStems: ['甲', '丙', '戊'] },
+        monthPillar: { stem: '辛', branch: '酉', hiddenStems: ['辛'] },
+        dayPillar:   { stem: '甲', branch: '子', hiddenStems: ['癸'] },
+        hourPillar:  { stem: '甲', branch: '寅', hiddenStems: ['甲', '丙', '戊'] }
+    };
+    const tsuuhenResult = {
+        year:  { tsuuhen: '比肩' },
+        month: { tsuuhen: '正官' },
+        hour:  { tsuuhen: '比肩' }
+    };
+    // 比劫奪官の薬=財=土。調候 primary に土を入れて一致させる
+    const kishouResult = {
+        temperature: '涼',
+        humidity: '中',
+        clarity: '不明',
+        severity: 'mild',
+        isExtreme: false,
+        choukou: { direction: '温める', primaryElements: ['土'], secondary: [] },
+        causeElements: [],
+        deficientElements: ['土'],
+        summary: 'テスト調候'
+    };
+    const keizenResult = {
+        pillar: {
+            kakkyoku: '正官格',
+            youshinCategory: 'officer',
+            youshinLabel: '官殺',
+            isEstablished: true
+        },
+        breaks: [{ condition: '比劫多', name: '比劫奪官' }],
+        supports: [],
+        summary: '比劫奪官'
+    };
+
+    const result = calculator.diagnose({
+        kakkyokuResult,
+        strengthResult,
+        fortuneResult,
+        tsuuhenResult,
+        kishouResult,
+        keizenResult
+    });
+
+    assert.strictEqual(result.meta.choukouAligned, true);
+    assert.ok(result.balance?.label, 'balance.label がある');
+    assert.ok(result.kiki?.ki?.length >= 1, '喜に薬がある');
+    assert.ok(result.kiki?.ji?.length >= 1, '忌に病がある');
+});
+
+test('ByoyakuCalculator - 調候不一致なら medicineSecondary を併記', () => {
+    const kakkyokuResult = {
+        kakkyoku: '正官格',
+        category: 'regular',
+        isEstablished: true,
+        breakReason: null
+    };
+    const strengthResult = { strength: 'strong', score: 5 };
+    const fortuneResult = {
+        yearPillar:  { stem: '甲', branch: '寅', hiddenStems: ['甲', '丙', '戊'] },
+        monthPillar: { stem: '辛', branch: '酉', hiddenStems: ['辛'] },
+        dayPillar:   { stem: '甲', branch: '子', hiddenStems: ['癸'] },
+        hourPillar:  { stem: '甲', branch: '寅', hiddenStems: ['甲', '丙', '戊'] }
+    };
+    const tsuuhenResult = {
+        year:  { tsuuhen: '比肩' },
+        month: { tsuuhen: '正官' },
+        hour:  { tsuuhen: '比肩' }
+    };
+    const kishouResult = {
+        temperature: '寒',
+        humidity: '湿',
+        clarity: '不明',
+        severity: 'moderate',
+        isExtreme: true,
+        choukou: { direction: '温める', primaryElements: ['火'], secondary: [] },
+        causeElements: ['水'],
+        deficientElements: ['火'],
+        summary: '寒湿'
+    };
+    const keizenResult = {
+        pillar: {
+            kakkyoku: '正官格',
+            youshinCategory: 'officer',
+            youshinLabel: '官殺',
+            isEstablished: true
+        },
+        breaks: [{ condition: '比劫多', name: '比劫奪官' }],
+        supports: [],
+        summary: '比劫奪官'
+    };
+
+    const result = calculator.diagnose({
+        kakkyokuResult,
+        strengthResult,
+        fortuneResult,
+        tsuuhenResult,
+        kishouResult,
+        keizenResult
+    });
+
+    const primary = result.diagnoses.find(d => d.source === 'keizen');
+    assert.ok(primary.medicineSecondary, '副薬（調候）がある');
+    assert.ok(primary.medicineSecondary.name.includes('温める'));
+    assert.ok(result.diagnoses.some(d => d.source === 'kishou'), '気象診断が併記される');
+    assert.strictEqual(result.disease.name, '比劫奪官', '代表病は用神損傷側');
 });
 
 test('ByoyakuCalculator - diagnose v2 は kishou/keizen 必須', () => {

--- a/chrome-extension/tests/core/DaiunHyoukaCalculator.test.js
+++ b/chrome-extension/tests/core/DaiunHyoukaCalculator.test.js
@@ -189,3 +189,75 @@ test('DaiunHyoukaCalculator - 空サイクルで空配列', () => {
     const results = calculator.evaluate([], byoyakuResult, fortuneResult, strengthResult);
     assert.strictEqual(results.length, 0, '空配列');
 });
+
+test('AC-05 表示先頭が気象診断でも代表病薬を評価する', () => {
+    const cycles = [
+        { cycleNumber: 1, ageStart: 3, ageEnd: 12, stem: '甲', branch: '寅', jiaziIndex: 0 }
+    ];
+    const fortuneResult = {
+        dayPillar: { stem: '甲', branch: '子', hiddenStems: ['癸'] }
+    };
+    const representativeDisease = { name: '比劫旺', element: '木', tenGod: '比肩', severity: 'moderate' };
+    const representativeMedicine = { name: '官殺', element: '金', tenGod: '正官', exists: false, location: null };
+    const byoyakuResult = {
+        disease: representativeDisease,
+        medicine: representativeMedicine,
+        diagnoses: [
+            {
+                role: 'secondary', source: 'kishou',
+                disease: { name: '気象偏枯', element: null, tenGod: null, severity: 'severe' },
+                medicine: { name: '調候', element: '火', tenGod: null, exists: false, location: null }
+            },
+            {
+                role: 'primary', source: 'keizen',
+                disease: representativeDisease,
+                medicine: representativeMedicine
+            }
+        ]
+    };
+
+    const results = calculator.evaluate(
+        cycles, byoyakuResult, fortuneResult, { strength: 'strong', score: 5 }
+    );
+    assert.strictEqual(results.length, 1);
+    assert.ok(results[0].score < 0, '代表病の木を凶として評価');
+});
+
+test('AC-05 代表病または代表薬がnullなら非null側だけ評価する', () => {
+    const cycles = [
+        { cycleNumber: 1, ageStart: 3, ageEnd: 12, stem: '壬', branch: '子', jiaziIndex: 48 }
+    ];
+    const fortuneResult = {
+        dayPillar: { stem: '甲', branch: '子', hiddenStems: ['癸'] }
+    };
+    const byoyakuResult = {
+        disease: { name: '気象偏枯', element: null },
+        medicine: { name: '調候', element: '水' },
+        diagnoses: []
+    };
+
+    const results = calculator.evaluate(
+        cycles, byoyakuResult, fortuneResult, { strength: 'weak', score: 0 }
+    );
+    assert.strictEqual(results.length, 1);
+    assert.ok(results[0].score > 0, '薬の水だけで評価');
+});
+
+test('AC-05 代表病薬の五行が両方nullなら大運評価をスキップする', () => {
+    const cycles = [
+        { cycleNumber: 1, ageStart: 3, ageEnd: 12, stem: '壬', branch: '子', jiaziIndex: 48 }
+    ];
+    const byoyakuResult = {
+        disease: { name: '未確定', element: null },
+        medicine: { name: '未確定', element: null },
+        diagnoses: []
+    };
+    const fortuneResult = {
+        dayPillar: { stem: '甲', branch: '子', hiddenStems: ['癸'] }
+    };
+
+    const results = calculator.evaluate(
+        cycles, byoyakuResult, fortuneResult, { strength: 'neutral', score: 2 }
+    );
+    assert.deepStrictEqual(results, []);
+});

--- a/chrome-extension/tests/run_tests.js
+++ b/chrome-extension/tests/run_tests.js
@@ -22,9 +22,9 @@ global.assert = {
     ok: (value, message) => {
         if (!value) throw new Error(`${message || ''} Expected truthy value`);
     },
-    throws: async (block, errorMatch, message) => {
+    throws: (block, errorMatch, message) => {
         try {
-            await block();
+            block();
         } catch (e) {
             if (errorMatch) {
                 if (typeof errorMatch === 'string' && !e.message.includes(errorMatch)) {


### PR DESCRIPTION
## 概要

- 月干1.2、月支主気2.0、日干除外の標準分布をByoyakuCalculatorへ接続
- 從重40%を雕より優先し、旺・長・損・生・益・琢を仕様どおり分類
- 調候と十神薬を突合し、気象診断、balance、kikiを追加
- T-03c / T-03d完了後のタスクリストをSprint B3へ更新

## レビューで修正した問題

- v2診断がKeizen breaksを使わず旧conditionを再計算していた問題を修正
- ルール外のbreakも合成診断として保持
- 調候薬の命式内所在を正しく設定
- 気象診断が表示先頭でも大運評価は代表病薬を参照
- 代表病薬の五行が片側nullなら非null側のみ評価し、両側nullならスキップ
- 同期例外テストが実際には検証されていなかったテストランナーを修正

## テスト

- npm test: 128 passed, 0 failed
- 從重40%境界 0.399 / 0.400 / 0.401
- Keizen breaks優先とルール外break保持
- AC-05代表病薬null境界
- git diff --check: 問題なし（CRLFはcr-at-eol指定）

## 後続タスク

- T-04 ResultRenderer
- T-07 UI受入 S-01〜S-07
- T-08 USER_GUIDE / manifest
