### PR TITLE
feat: implement P1 time correction service

### DIFF
--- a/chrome-extension/docs/design/時刻補正機能_詳細設計/11_実装タスクリスト_フェーズ計画.md
+++ b/chrome-extension/docs/design/時刻補正機能_詳細設計/11_実装タスクリスト_フェーズ計画.md
@@ -71,18 +71,18 @@
 
 ### 実装タスク
 
-- [ ] P1-1 `js/core/TimeCorrectionService.js` 実装
+- [x] P1-1 `js/core/TimeCorrectionService.js` 実装
   - コンストラクタでマスタ注入
   - `correct` / `parseOffset` / `formatOffset`
   - `Math.round(4*(lon-135))`
   - `applied: true`（時刻あり前提）
-- [ ] P1-2 表示用文字列（input / offset / longitude / corrected）
+- [x] P1-2 表示用文字列（input / offset / longitude / corrected）
 
 ### テスト（必須）
 
-- [ ] P1-T1 `TimeCorrectionService.test.js` で **TC-01〜08, TC-10〜14** を実装・グリーン
+- [x] P1-T1 `TimeCorrectionService.test.js` で **TC-01〜08, TC-10〜14** を実装・グリーン
   - TC-02 に東京 **+19分** と表示文字列（`+19分` / 東京都）を含める
-- [ ] P1-T2 P0テスト継続グリーン
+- [x] P1-T2 P0テスト継続グリーン
 - [ ] **TC-09（±24:00）はP4**。本フェーズの完了条件に含めない
 
 ### 完了ゲート

--- a/chrome-extension/js/core/TimeCorrectionService.js
+++ b/chrome-extension/js/core/TimeCorrectionService.js
@@ -1,0 +1,146 @@
+/**
+ * 時刻補正サービス
+ * 時差・地方平均時補正と表示用文字列の生成。干支計算・DOM・入力検証は行わない。
+ */
+
+import { DateUtils } from '../utils/dateUtils.js';
+import { CalculationError } from '../utils/errors.js';
+import { JST_REFERENCE_LONGITUDE } from '../utils/constants.js';
+
+function pad2(value) {
+  return String(value).padStart(2, '0');
+}
+
+function formatDateTime({ year, month, day, hour, minute }) {
+  return `${year}-${pad2(month)}-${pad2(day)} ${pad2(hour)}:${pad2(minute)}`;
+}
+
+function formatSignedMinutes(minutes) {
+  const sign = minutes > 0 ? '+' : '';
+  return `${sign}${minutes}分`;
+}
+
+export class TimeCorrectionService {
+  /**
+   * @param {object} longitudeMaster - prefecture_longitude.json
+   */
+  constructor(longitudeMaster) {
+    if (!TimeCorrectionService._isValidMaster(longitudeMaster)) {
+      throw new CalculationError('経度マスタが不正です');
+    }
+    this.master = longitudeMaster;
+    this.byCode = new Map(longitudeMaster.prefectures.map((p) => [p.code, p]));
+  }
+
+  static _isValidMaster(master) {
+    if (
+      !master ||
+      master.referenceMeridianEast !== JST_REFERENCE_LONGITUDE ||
+      !Array.isArray(master.prefectures) ||
+      master.prefectures.length !== 47
+    ) {
+      return false;
+    }
+
+    const codes = new Set();
+    return master.prefectures.every((prefecture) => {
+      if (
+        !prefecture ||
+        typeof prefecture.code !== 'string' ||
+        !/^\d{2}$/.test(prefecture.code) ||
+        typeof prefecture.name !== 'string' ||
+        prefecture.name.length === 0 ||
+        !Number.isFinite(prefecture.longitudeEast)
+      ) {
+        return false;
+      }
+      codes.add(prefecture.code);
+      return true;
+    }) && codes.size === 47;
+  }
+
+  /**
+   * UIの符号・時・分を分単位オフセットへ変換する。
+   * @param {string|number} sign '+' / '-' または 1 / -1
+   * @param {number|string} hour
+   * @param {number|string} minute
+   * @returns {number}
+   */
+  static parseOffset(sign, hour, minute) {
+    const negative = sign === '-' || sign === -1 || sign === '-1';
+    const signFactor = negative ? -1 : 1;
+    return signFactor * (Number(hour) * 60 + Number(minute));
+  }
+
+  /**
+   * 分単位オフセットを "+05:30" 形式にする。
+   * @param {number} offsetMinutes
+   * @returns {string}
+   */
+  static formatOffset(offsetMinutes) {
+    const sign = offsetMinutes < 0 ? '-' : '+';
+    const abs = Math.abs(offsetMinutes);
+    const hours = Math.floor(abs / 60);
+    const minutes = abs % 60;
+    return `${sign}${pad2(hours)}:${pad2(minutes)}`;
+  }
+
+  /**
+   * 時刻あり前提の補正。applied は補正量0でも true。
+   * 時差範囲外の検証は InputManager の責務（TC-09）。
+   */
+  correct({ year, month, day, hour, minute, prefectureCode, offsetMinutes }) {
+    const offset = offsetMinutes ?? 0;
+    const { longitudeOffsetMinutes, prefecture } = this._resolvePrefecture(prefectureCode);
+    const totalOffsetMinutes = offset + longitudeOffsetMinutes;
+    const input = { year, month, day, hour, minute };
+    const corrected = DateUtils.addMinutes(year, month, day, hour, minute, totalOffsetMinutes);
+
+    return {
+      applied: true,
+      input,
+      corrected,
+      offsetMinutes: offset,
+      longitudeOffsetMinutes,
+      totalOffsetMinutes,
+      prefecture,
+      display: {
+        statusText: '適用',
+        inputText: formatDateTime(input),
+        offsetText: `${TimeCorrectionService.formatOffset(offset)}（${offset}分）`,
+        longitudeText: this._formatLongitudeText(prefecture, longitudeOffsetMinutes),
+        correctedText: formatDateTime(corrected),
+      },
+    };
+  }
+
+  _resolvePrefecture(prefectureCode) {
+    if (prefectureCode == null || prefectureCode === '') {
+      return { longitudeOffsetMinutes: 0, prefecture: null };
+    }
+
+    const pref = this.byCode.get(prefectureCode);
+    if (!pref) {
+      throw new CalculationError(`経度マスタに存在しない都道府県コードです: ${prefectureCode}`);
+    }
+
+    const reference = this.master.referenceMeridianEast;
+    const longitudeOffsetMinutes = Math.round(4 * (pref.longitudeEast - reference));
+    return {
+      longitudeOffsetMinutes,
+      prefecture: {
+        code: pref.code,
+        name: pref.name,
+        longitudeEast: pref.longitudeEast,
+      },
+    };
+  }
+
+  _formatLongitudeText(prefecture, longitudeOffsetMinutes) {
+    const minutesText = formatSignedMinutes(longitudeOffsetMinutes);
+    if (!prefecture) {
+      return minutesText;
+    }
+    return `${minutesText}（${prefecture.name} / 東経${prefecture.longitudeEast}°）`;
+  }
+}

--- a/chrome-extension/tests/core/TimeCorrectionService.test.js
+++ b/chrome-extension/tests/core/TimeCorrectionService.test.js
@@ -1,0 +1,219 @@
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { TimeCorrectionService } from '../../js/core/TimeCorrectionService.js';
+import { DateUtils } from '../../js/utils/dateUtils.js';
+import { JST_REFERENCE_LONGITUDE } from '../../js/utils/constants.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MASTER_PATH = path.resolve(__dirname, '../../data/prefecture_longitude.json');
+const master = JSON.parse(fs.readFileSync(MASTER_PATH, 'utf8'));
+const service = new TimeCorrectionService(master);
+
+const BASE = { year: 1990, month: 5, day: 1, hour: 8, minute: 30 };
+
+function expectedLongitudeOffset(longitudeEast) {
+  return Math.round(4 * (longitudeEast - JST_REFERENCE_LONGITUDE));
+}
+
+test('TC-01 offset 0 and no prefecture keeps input and applied true', async () => {
+  const result = service.correct({ ...BASE, prefectureCode: null, offsetMinutes: 0 });
+  assert.strictEqual(result.applied, true);
+  assert.deepStrictEqual(result.corrected, BASE);
+  assert.strictEqual(result.offsetMinutes, 0);
+  assert.strictEqual(result.longitudeOffsetMinutes, 0);
+  assert.strictEqual(result.totalOffsetMinutes, 0);
+  assert.strictEqual(result.prefecture, null);
+  assert.strictEqual(result.display.statusText, '適用');
+  assert.strictEqual(result.display.inputText, '1990-05-01 08:30');
+  assert.strictEqual(result.display.correctedText, '1990-05-01 08:30');
+  assert.strictEqual(result.display.offsetText, '+00:00（0分）');
+});
+
+test('TC-02 Tokyo only adds +19 minutes and display includes +19分 / 東京都', async () => {
+  const tokyo = master.prefectures.find((p) => p.code === '13');
+  const lonOffset = expectedLongitudeOffset(tokyo.longitudeEast);
+  assert.strictEqual(lonOffset, 19, 'Tokyo longitude must round to +19');
+
+  const result = service.correct({ ...BASE, prefectureCode: '13', offsetMinutes: 0 });
+  assert.strictEqual(result.applied, true);
+  assert.strictEqual(result.longitudeOffsetMinutes, 19);
+  assert.strictEqual(result.totalOffsetMinutes, 19);
+  assert.deepStrictEqual(result.corrected, { year: 1990, month: 5, day: 1, hour: 8, minute: 49 });
+  assert.strictEqual(result.prefecture.name, '東京都');
+  assert.ok(result.display.longitudeText.includes('+19分'), result.display.longitudeText);
+  assert.ok(result.display.longitudeText.includes('東京都'), result.display.longitudeText);
+  assert.strictEqual(result.display.correctedText, '1990-05-01 08:49');
+});
+
+test('TC-03 Hyogo near Akashi is nearly 0 minutes', async () => {
+  const hyogo = master.prefectures.find((p) => p.code === '28');
+  const lonOffset = expectedLongitudeOffset(hyogo.longitudeEast);
+  const result = service.correct({ ...BASE, prefectureCode: '28', offsetMinutes: 0 });
+  assert.strictEqual(result.longitudeOffsetMinutes, lonOffset);
+  assert.ok(Math.abs(result.longitudeOffsetMinutes) <= 1, 'Hyogo offset should be nearly 0');
+  assert.strictEqual(result.prefecture.name, '兵庫県');
+  assert.deepStrictEqual(
+    result.corrected,
+    DateUtils.addMinutes(BASE.year, BASE.month, BASE.day, BASE.hour, BASE.minute, lonOffset)
+  );
+});
+
+test('TC-04 timezone offset +60 adds one hour', async () => {
+  assert.strictEqual(TimeCorrectionService.parseOffset('+', 1, 0), 60);
+  assert.strictEqual(TimeCorrectionService.formatOffset(60), '+01:00');
+  const result = service.correct({ ...BASE, prefectureCode: null, offsetMinutes: 60 });
+  assert.deepStrictEqual(result.corrected, { year: 1990, month: 5, day: 1, hour: 9, minute: 30 });
+  assert.strictEqual(result.offsetMinutes, 60);
+  assert.strictEqual(result.longitudeOffsetMinutes, 0);
+  assert.strictEqual(result.totalOffsetMinutes, 60);
+  assert.strictEqual(result.display.offsetText, '+01:00（60分）');
+});
+
+test('TC-05 timezone and longitude offsets are summed', async () => {
+  const result = service.correct({ ...BASE, prefectureCode: '13', offsetMinutes: 60 });
+  assert.strictEqual(result.totalOffsetMinutes, 79);
+  assert.deepStrictEqual(result.corrected, { year: 1990, month: 5, day: 1, hour: 9, minute: 49 });
+  assert.strictEqual(result.display.correctedText, '1990-05-01 09:49');
+});
+
+test('TC-06 23:50 plus 20 minutes rolls to next day 00:10', async () => {
+  const result = service.correct({
+    year: 1990,
+    month: 5,
+    day: 1,
+    hour: 23,
+    minute: 50,
+    prefectureCode: null,
+    offsetMinutes: 20,
+  });
+  assert.deepStrictEqual(result.corrected, { year: 1990, month: 5, day: 2, hour: 0, minute: 10 });
+  assert.strictEqual(result.display.correctedText, '1990-05-02 00:10');
+});
+
+test('TC-07 00:10 minus 20 minutes rolls to previous day 23:50', async () => {
+  const result = service.correct({
+    year: 1990,
+    month: 5,
+    day: 1,
+    hour: 0,
+    minute: 10,
+    prefectureCode: null,
+    offsetMinutes: -20,
+  });
+  assert.deepStrictEqual(result.corrected, { year: 1990, month: 4, day: 30, hour: 23, minute: 50 });
+  assert.strictEqual(result.display.correctedText, '1990-04-30 23:50');
+});
+
+test('TC-08 offset ±23:59 is accepted by the service', async () => {
+  assert.strictEqual(TimeCorrectionService.parseOffset('+', 23, 59), 1439);
+  assert.strictEqual(TimeCorrectionService.parseOffset('-', 23, 59), -1439);
+  assert.strictEqual(TimeCorrectionService.formatOffset(1439), '+23:59');
+  assert.strictEqual(TimeCorrectionService.formatOffset(-1439), '-23:59');
+
+  const plus = service.correct({
+    year: 1990,
+    month: 5,
+    day: 1,
+    hour: 12,
+    minute: 0,
+    prefectureCode: null,
+    offsetMinutes: 1439,
+  });
+  assert.deepStrictEqual(plus.corrected, { year: 1990, month: 5, day: 2, hour: 11, minute: 59 });
+  assert.strictEqual(plus.applied, true);
+
+  const minus = service.correct({
+    year: 1990,
+    month: 5,
+    day: 1,
+    hour: 12,
+    minute: 0,
+    prefectureCode: null,
+    offsetMinutes: -1439,
+  });
+  assert.deepStrictEqual(minus.corrected, { year: 1990, month: 4, day: 30, hour: 12, minute: 1 });
+});
+
+test('TC-10 unknown prefecture throws an internal error', async () => {
+  await assert.throws(
+    async () => {
+      service.correct({ ...BASE, prefectureCode: '99', offsetMinutes: 0 });
+    },
+    '都道府県',
+    'unknown prefecture code should throw'
+  );
+});
+
+test('TC-10 malformed longitude master throws during initialization', async () => {
+  const missingReference = { ...master, referenceMeridianEast: undefined };
+  await assert.throws(
+    async () => {
+      new TimeCorrectionService(missingReference);
+    },
+    '経度マスタが不正',
+    'missing reference meridian should be rejected'
+  );
+
+  const missingLongitude = {
+    ...master,
+    prefectures: master.prefectures.map((prefecture, index) =>
+      index === 0 ? { ...prefecture, longitudeEast: undefined } : prefecture
+    ),
+  };
+  await assert.throws(
+    async () => {
+      new TimeCorrectionService(missingLongitude);
+    },
+    '経度マスタが不正',
+    'missing longitude should be rejected'
+  );
+});
+
+test('TC-11 January 31 plus one day of minutes becomes February 1', async () => {
+  const result = service.correct({
+    year: 2023,
+    month: 1,
+    day: 31,
+    hour: 12,
+    minute: 0,
+    prefectureCode: null,
+    offsetMinutes: 1440,
+  });
+  assert.deepStrictEqual(result.corrected, { year: 2023, month: 2, day: 1, hour: 12, minute: 0 });
+});
+
+test('TC-12 December 31 23:50 plus 20 minutes becomes next year 00:10', async () => {
+  const result = service.correct({
+    year: 2023,
+    month: 12,
+    day: 31,
+    hour: 23,
+    minute: 50,
+    prefectureCode: null,
+    offsetMinutes: 20,
+  });
+  assert.deepStrictEqual(result.corrected, { year: 2024, month: 1, day: 1, hour: 0, minute: 10 });
+});
+
+test('TC-13 leap day: Feb 28 plus 20 minutes becomes Feb 29', async () => {
+  const result = service.correct({
+    year: 2024,
+    month: 2,
+    day: 28,
+    hour: 23,
+    minute: 50,
+    prefectureCode: null,
+    offsetMinutes: 20,
+  });
+  assert.deepStrictEqual(result.corrected, { year: 2024, month: 2, day: 29, hour: 0, minute: 10 });
+});
+
+test('TC-14 multi-day offset +3000 minutes matches day and time', async () => {
+  const result = service.correct({ ...BASE, prefectureCode: null, offsetMinutes: 3000 });
+  assert.deepStrictEqual(result.corrected, { year: 1990, month: 5, day: 3, hour: 10, minute: 30 });
+  assert.deepStrictEqual(
+    result.corrected,
+    DateUtils.addMinutes(BASE.year, BASE.month, BASE.day, BASE.hour, BASE.minute, 3000)
+  );
+});


### PR DESCRIPTION
## Summary
- `TimeCorrectionService`を追加し、時差・地方平均時補正・日跨ぎを実装
- 補正結果と画面表示用メタデータ（入力時刻、補正量、都道府県、補正後時刻）を生成
- TC-01〜08、TC-10〜14と経度マスタ破損時の異常系テストを追加
- P1タスクの完了状況をタスクリストへ反映

## Test plan
- [x] `node chrome-extension/tests/run_tests.js`（43 passed, 0 failed）
- [x] 変更ファイルのLint確認（エラーなし）
- [x] 破損マスタで`NaN`を返さず、`CalculationError`になることを確認

## Review follow-up
- 経度マスタの必須項目検証を追加し、破損データが補正計算へ流入しないように修正
- 既存FortuneCalculatorの日柱計算に残るOSタイムゾーン依存は、P2のJST固定化で対応予定

Made with [Cursor](https://cursor.com)