### PR TITLE
feat: implement P2 shi-mode fortune calculation

### DIFF
--- a/chrome-extension/docs/design/時刻補正機能_詳細設計/11_実装タスクリスト_フェーズ計画.md
+++ b/chrome-extension/docs/design/時刻補正機能_詳細設計/11_実装タスクリスト_フェーズ計画.md
@@ -97,19 +97,19 @@
 
 ### 実装タスク
 
-- [ ] P2-1 `resolveDayPillarDate` を `FortuneCalculator` に追加
-- [ ] P2-2 `calculateHourPillar` に `shiMode`（`switch23` / `switch00`）
-- [ ] P2-3 `calculateFortune` で年月柱=`t_corrected`、日柱=`resolveDayPillarDate`、時柱=モード適用
-- [ ] P2-4 節入り比較を `toJstEpochMillis` と `parseISOString`（offset保持）の epoch 比較へ切替
-- [ ] P2-5 既存23時台テスト期待値を V1.5 仕様へ更新（コメントで仕様変更を明記）
+- [x] P2-1 `resolveDayPillarDate` を `FortuneCalculator` に追加
+- [x] P2-2 `calculateHourPillar` に `shiMode`（`switch23` / `switch00`）
+- [x] P2-3 `calculateFortune` で年月柱=`t_corrected`、日柱=`resolveDayPillarDate`、時柱=モード適用
+- [x] P2-4 節入り比較を `toJstEpochMillis` と `parseISOString`（offset保持）の epoch 比較へ切替
+- [x] P2-5 既存23時台テスト期待値を V1.5 仕様へ更新（コメントで仕様変更を明記）
 
 ### テスト（必須）
 
-- [ ] P2-T1 **SM-01〜08**（時支・日柱・SM-02の時干）
-- [ ] P2-T2 **ST-02**（補正なし・非23時台で V1.0 同結果）
-- [ ] P2-T3 `resolveDayPillarDate` の境界（22/23/0/1時 × 両モード）
-- [ ] P2-T4 **ST-03**（数値JSTと節気ISOの epoch 境界。環境TZに依存しない式でアサーション）
-- [ ] P2-T5 既存 `FortuneCalculator` 関連テスト更新後グリーン
+- [x] P2-T1 **SM-01〜08**（時支・日柱・SM-02の時干）
+- [x] P2-T2 **ST-02**（補正なし・非23時台で V1.0 同結果）
+- [x] P2-T3 `resolveDayPillarDate` の境界（22/23/0/1時 × 両モード）
+- [x] P2-T4 **ST-03**（数値JSTと節気ISOの epoch 境界。環境TZに依存しない式でアサーション）
+- [x] P2-T5 既存 `FortuneCalculator` 関連テスト更新後グリーン
 
 ### 完了ゲート
 

--- a/chrome-extension/js/core/FortuneCalculator.js
+++ b/chrome-extension/js/core/FortuneCalculator.js
@@ -302,7 +302,13 @@ export class FortuneCalculator {
    * @private
    */
   _toInputEpoch(year, month, day, hour, minute) {
-    return DateUtils.toJstEpochMillis(year, month, day, hour ?? 0, minute ?? 0);
+    return DateUtils.createDate(
+      year,
+      month,
+      day,
+      hour ?? 0,
+      minute ?? 0,
+    ).getTime();
   }
 
   /**

--- a/chrome-extension/js/core/FortuneCalculator.js
+++ b/chrome-extension/js/core/FortuneCalculator.js
@@ -12,6 +12,8 @@ import {
   MONTH_TERM_TO_BRANCH,
   BRANCH_TO_MONTH_INDEX,
   BASE_DATE_JIAZI_INDEX,
+  SHI_MODE,
+  DEFAULT_SHI_MODE,
 } from "../utils/constants.js";
 
 import {
@@ -139,22 +141,18 @@ export class FortuneCalculator {
    * @throws {InvalidDateError} 無効な日時の場合
    */
   calculateYearPillarWithDate(year, month, day, hour, minute) {
-    // 入力日時を作成
-    const inputDt = DateUtils.createDate(year, month, day, hour, minute);
+    const inputEpoch = this._toInputEpoch(year, month, day, hour, minute);
 
-    // 立春の日時を取得
     try {
-      const risshun = this.getSolarTermDateTime(year, "立春");
+      const risshunEpoch = this.getSolarTermDateTime(year, "立春").getTime();
 
-      // 立春前なら前年の干支
-      if (inputDt < risshun) {
+      // 立春前なら前年の干支（JST epoch 比較。OS TZ非依存）
+      if (inputEpoch < risshunEpoch) {
         return this.calculateYearPillar(year - 1);
-      } else {
-        return this.calculateYearPillar(year);
       }
+      return this.calculateYearPillar(year);
     } catch (error) {
       if (error instanceof SolarTermNotFoundError) {
-        // 現在の年の立春が見つからない場合は、年だけで計算
         return this.calculateYearPillar(year);
       }
       throw error;
@@ -174,13 +172,13 @@ export class FortuneCalculator {
    * @throws {InvalidDateError} 無効な日時の場合
    */
   calculateMonthPillar(year, month, day, hour, minute) {
-    const inputDt = DateUtils.createDate(year, month, day, hour, minute);
+    const inputEpoch = this._toInputEpoch(year, month, day, hour, minute);
 
     // 年データの存在確認
     this._validateYearDataExists(year);
 
     // 月支を判定
-    const monthBranch = this._determineMonthBranch(year, inputDt);
+    const monthBranch = this._determineMonthBranch(year, inputEpoch);
 
     // 月干を計算（年干から月干を求める）
     const { stem: yearStem } = this.calculateYearPillarWithDate(
@@ -213,24 +211,24 @@ export class FortuneCalculator {
    * 入力日時から月支を判定
    *
    * @param {number} year - 西暦年
-   * @param {Date} inputDt - 入力日時
+   * @param {number} inputEpoch - 入力日時の UTC epoch millis
    * @returns {string} 月支（子、丑、寅など）
    * @throws {CalculationError} 月支の判定に失敗した場合
    * @private
    */
-  _determineMonthBranch(year, inputDt) {
+  _determineMonthBranch(year, inputEpoch) {
     const monthTerms = Object.keys(MONTH_TERM_TO_BRANCH);
 
     // 各節気の期間を確認
     for (let i = 0; i < monthTerms.length; i++) {
       const termName = monthTerms[i];
-      if (this._isInTermPeriod(year, i, termName, monthTerms, inputDt)) {
+      if (this._isInTermPeriod(year, i, termName, monthTerms, inputEpoch)) {
         return MONTH_TERM_TO_BRANCH[termName];
       }
     }
 
     // 立春前の特殊ケース（年初）を処理
-    return this._handleEarlyYearCase(year, inputDt);
+    return this._handleEarlyYearCase(year, inputEpoch);
   }
 
   /**
@@ -240,15 +238,15 @@ export class FortuneCalculator {
    * @param {number} termIndex - 節気のインデックス
    * @param {string} termName - 節気名
    * @param {string[]} monthTerms - 節気名のリスト
-   * @param {Date} inputDt - 入力日時
+   * @param {number} inputEpoch - 入力日時の UTC epoch millis
    * @returns {boolean} 期間内の場合true
    * @private
    */
-  _isInTermPeriod(year, termIndex, termName, monthTerms, inputDt) {
-    const termDt = this.getSolarTermDateTime(year, termName);
-    const nextTermDt = this._getNextTermDateTime(year, termIndex, monthTerms);
+  _isInTermPeriod(year, termIndex, termName, monthTerms, inputEpoch) {
+    const termEpoch = this.getSolarTermDateTime(year, termName).getTime();
+    const nextTermEpoch = this._getNextTermDateTime(year, termIndex, monthTerms).getTime();
 
-    return termDt <= inputDt && inputDt < nextTermDt;
+    return termEpoch <= inputEpoch && inputEpoch < nextTermEpoch;
   }
 
   /**
@@ -276,29 +274,35 @@ export class FortuneCalculator {
    * 立春前の特殊ケースを処理
    *
    * @param {number} year - 西暦年
-   * @param {Date} inputDt - 入力日時
+   * @param {number} inputEpoch - 入力日時の UTC epoch millis
    * @returns {string} 月支（丑または子）
    * @throws {CalculationError} 月支の判定に失敗した場合
    * @private
    */
-  _handleEarlyYearCase(year, inputDt) {
-    const risshun = this.getSolarTermDateTime(year, "立春");
+  _handleEarlyYearCase(year, inputEpoch) {
+    const risshunEpoch = this.getSolarTermDateTime(year, "立春").getTime();
 
-    if (inputDt < risshun) {
+    if (inputEpoch < risshunEpoch) {
       // 小寒と立春の間なら丑月、小寒前なら子月
       try {
-        const shokan = this.getSolarTermDateTime(year, "小寒");
-        return inputDt >= shokan ? "丑" : "子";
+        const shokanEpoch = this.getSolarTermDateTime(year, "小寒").getTime();
+        return inputEpoch >= shokanEpoch ? "丑" : "子";
       } catch (error) {
         if (error instanceof SolarTermNotFoundError) {
-          // 小寒のデータがない場合は丑月とする（フォールバック）
           return "丑";
         }
         throw error;
       }
-    } else {
-      throw new CalculationError("月支の判定に失敗しました");
     }
+    throw new CalculationError("月支の判定に失敗しました");
+  }
+
+  /**
+   * JST暦の数値日時 → UTC epoch millis
+   * @private
+   */
+  _toInputEpoch(year, month, day, hour, minute) {
+    return DateUtils.toJstEpochMillis(year, month, day, hour ?? 0, minute ?? 0);
   }
 
   /**
@@ -364,11 +368,10 @@ export class FortuneCalculator {
    *
    * @description
    * 日柱は暦の日付で計算します。節入り時刻は月柱の計算に使用し、
-   * 日柱には影響しません。23時台の日跨ぎ処理は時柱で行います。
+   * 日柱には影響しません。23時台の日跨ぎは `resolveDayPillarDate` が担う。
    */
   calculateDayPillar(year, month, day, hour = 12, minute = 0) {
-    // 日付の妥当性チェック
-    DateUtils.createDate(year, month, day, hour, minute);
+    DateUtils.createDate(year, month, day);
 
     if (!this.stemBranchData || !this.stemBranchData.sixty_jiazi) {
       throw new CalculationError("干支データが初期化されていません");
@@ -392,15 +395,31 @@ export class FortuneCalculator {
     // 参考:
     //   - BASE_DATE_JIAZI_INDEX = 10 (constants.jsで定義)
     //   - 六十甲子: 甲子(0), 乙丑(1), ... , 甲戌(10), ... , 癸亥(59)
-    const baseDate = new Date(1900, 0, 1); // 1900年1月1日
-
-    // 暦上の日柱を計算（節入り時刻は考慮しない）
-    const inputDate = new Date(year, month - 1, day);
-    const deltaDays = DateUtils.getDaysDifference(baseDate, inputDate);
-    const jiaziIndex = (BASE_DATE_JIAZI_INDEX + deltaDays) % 60;
+    const baseDate = DateUtils.createDate(1900, 1, 1);
+    const inputDate = DateUtils.createDate(year, month, day);
+    const deltaDays = DateUtils.getCalendarDaysDifference(baseDate, inputDate);
+    const jiaziIndex = (((BASE_DATE_JIAZI_INDEX + deltaDays) % 60) + 60) % 60;
 
     const jiazi = this.stemBranchData.sixty_jiazi[jiaziIndex];
     return { stem: jiazi.stem, branch: jiazi.branch };
+  }
+
+  /**
+   * 日柱・時干用の暦日を解決する。年柱・月柱・大運には使わない。
+   * switch23 かつ 23時台のときのみ翌日。
+   *
+   * @param {number} year
+   * @param {number} month
+   * @param {number} day
+   * @param {number|null} hour
+   * @param {string} shiMode
+   * @returns {{year:number, month:number, day:number}}
+   */
+  resolveDayPillarDate(year, month, day, hour, shiMode = DEFAULT_SHI_MODE) {
+    if (shiMode === SHI_MODE.SWITCH_23 && hour === 23) {
+      return DateUtils.addDays(year, month, day, 1);
+    }
+    return { year, month, day };
   }
 
   /**
@@ -409,14 +428,16 @@ export class FortuneCalculator {
    * @param {number} hour - 時（0-23）
    * @param {number} minute - 分（0-59）
    * @param {string} dayStem - 日の天干（時柱の天干計算に必要）
+   * @param {string} shiMode - `switch23`（既定）または `switch00`
    * @returns {{stem: string, branch: string}} 時柱
    * @throws {InvalidDateError} 無効な時刻の場合
    * @throws {CalculationError} 無効な日干の場合
    *
    * @description
-   * 23時台は翌日の子時として扱う
+   * switch23: 23:00-00:59 を子時。日柱の翌日扱いは resolveDayPillarDate 側。
+   * switch00: 00:00-01:59 を子時。23時台は亥。
    */
-  calculateHourPillar(hour, minute, dayStem) {
+  calculateHourPillar(hour, minute, dayStem, shiMode = DEFAULT_SHI_MODE) {
     if (hour < 0 || hour > 23) {
       throw new InvalidDateError(`無効な時刻です: ${hour}時`);
     }
@@ -424,18 +445,12 @@ export class FortuneCalculator {
       throw new InvalidDateError(`無効な分です: ${minute}分`);
     }
 
-    // 時支を決定（数式ベース）
-    // 23:00-00:59 → 子時（インデックス0）
-    // 01:00-02:59 → 丑時（インデックス1）
-    // ...
-    // 21:00-22:59 → 亥時（インデックス11）
-    //
-    // 23時台は翌日の0時として扱うため (hour + 1) % 24 で正規化
-    // 2時間ごとにインデックスが1つ進むため 2 で割る
-    const hourBranchIndex = Math.floor(((hour + 1) % 24) / 2);
+    const hourBranchIndex =
+      shiMode === SHI_MODE.SWITCH_00
+        ? Math.floor(hour / 2)
+        : Math.floor(((hour + 1) % 24) / 2);
     const hourBranch = HOUR_BRANCHES[hourBranchIndex];
 
-    // 時干を計算（五虎遁日起時訣）
     if (!HOUR_STEM_TABLE[dayStem]) {
       throw new CalculationError(`無効な日干です: ${dayStem}`);
     }
@@ -453,6 +468,8 @@ export class FortuneCalculator {
    * @param {number} day - 日
    * @param {number} hour - 時（0-23）
    * @param {number} minute - 分
+   * @param {object} [options]
+   * @param {string} [options.shiMode='switch23']
    * @returns {{
    *   yearPillar: {stem: string, branch: string, hiddenStems: string[]},
    *   monthPillar: {stem: string, branch: string, hiddenStems: string[]},
@@ -460,8 +477,10 @@ export class FortuneCalculator {
    *   hourPillar: {stem: string, branch: string, hiddenStems: string[]}
    * }} 完全な命式
    */
-  calculateFortune(year, month, day, hour, minute) {
-    // 年柱
+  calculateFortune(year, month, day, hour, minute, options = {}) {
+    const shiMode = options.shiMode ?? DEFAULT_SHI_MODE;
+
+    // 年柱・月柱は t_corrected（呼び出し側が渡す日時）を使う。子時の人工+1日は適用しない。
     const yearPillar = this.calculateYearPillarWithDate(
       year,
       month,
@@ -471,7 +490,6 @@ export class FortuneCalculator {
     );
     const yearHidden = this.getHiddenStems(yearPillar.branch);
 
-    // 月柱
     const monthPillar = this.calculateMonthPillar(
       year,
       month,
@@ -481,17 +499,18 @@ export class FortuneCalculator {
     );
     const monthHidden = this.getHiddenStems(monthPillar.branch);
 
-    // 日柱（節入り時刻による補正のため時刻も渡す）
-    const dayPillar = this.calculateDayPillar(year, month, day, hour, minute);
+    // 日柱・時干のみ resolveDayPillarDate
+    const dayYmd = this.resolveDayPillarDate(year, month, day, hour, shiMode);
+    const dayPillar = this.calculateDayPillar(dayYmd.year, dayYmd.month, dayYmd.day);
     const dayHidden = this.getHiddenStems(dayPillar.branch);
 
-    // 時柱（時刻が指定されている場合のみ計算）
     let hourPillarResult = null;
     if (hour !== null && hour !== undefined) {
       const hourPillar = this.calculateHourPillar(
         hour,
         minute || 0,
         dayPillar.stem,
+        shiMode,
       );
       const hourHidden = this.getHiddenStems(hourPillar.branch);
       hourPillarResult = {

--- a/chrome-extension/tests/core/FortuneCalculator.shiMode.test.js
+++ b/chrome-extension/tests/core/FortuneCalculator.shiMode.test.js
@@ -1,0 +1,170 @@
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { FortuneCalculator } from '../../js/core/FortuneCalculator.js';
+import { DateUtils } from '../../js/utils/dateUtils.js';
+import { SHI_MODE, DEFAULT_SHI_MODE } from '../../js/utils/constants.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = path.resolve(__dirname, '../../data');
+
+class MockDataLoader {
+  constructor(basePath) {
+    this.basePath = basePath;
+  }
+
+  async loadJSON(filename) {
+    const filePath = path.join(this.basePath, filename);
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  }
+
+  async loadSolarTerms() {
+    return this.loadJSON('solar_terms.json');
+  }
+
+  async loadStemBranchMaster() {
+    return this.loadJSON('stem_branch_master.json');
+  }
+}
+
+const BASE = { year: 2023, month: 6, day: 15 };
+let calculator;
+
+test('FortuneCalculator.shiMode initialize', async () => {
+  calculator = new FortuneCalculator(new MockDataLoader(DATA_DIR));
+  await calculator.initialize();
+  assert.ok(calculator.solarTermsData);
+});
+
+function pillar(result, key) {
+  return `${result[key].stem}${result[key].branch}`;
+}
+
+test('SM-01 12:00 switch23 is 午 and same-day pillar', async () => {
+  const result = calculator.calculateFortune(2023, 6, 15, 12, 0, { shiMode: SHI_MODE.SWITCH_23 });
+  assert.strictEqual(result.hourPillar.branch, '午');
+  assert.strictEqual(pillar(result, 'dayPillar'), '甲辰');
+  assert.strictEqual(pillar(result, 'hourPillar'), '庚午');
+});
+
+test('SM-02 23:30 switch23 is 子, next-day pillar, and hour stem from next day', async () => {
+  // V1.5 仕様変更: V1.0 は 23時台でも日柱を進めない。switch23 では翌日の日柱・時干を使う。
+  const sameDay = calculator.calculateDayPillar(2023, 6, 15);
+  const nextDay = calculator.calculateDayPillar(2023, 6, 16);
+  assert.strictEqual(`${sameDay.stem}${sameDay.branch}`, '甲辰');
+  assert.strictEqual(`${nextDay.stem}${nextDay.branch}`, '乙巳');
+
+  const result = calculator.calculateFortune(2023, 6, 15, 23, 30, { shiMode: SHI_MODE.SWITCH_23 });
+  assert.strictEqual(result.hourPillar.branch, '子');
+  assert.strictEqual(pillar(result, 'dayPillar'), '乙巳', 'day pillar must be next calendar day');
+  assert.strictEqual(pillar(result, 'hourPillar'), '丙子', 'hour stem uses next-day 乙巳');
+  assert.strictEqual(pillar(result, 'yearPillar'), '癸卯', 'year pillar must stay on t_corrected day');
+  assert.strictEqual(pillar(result, 'monthPillar'), '戊午', 'month pillar must stay on t_corrected day');
+});
+
+test('SM-03 00:30 switch23 is 子 and same-day pillar', async () => {
+  const result = calculator.calculateFortune(2023, 6, 15, 0, 30, { shiMode: SHI_MODE.SWITCH_23 });
+  assert.strictEqual(result.hourPillar.branch, '子');
+  assert.strictEqual(pillar(result, 'dayPillar'), '甲辰');
+  assert.strictEqual(pillar(result, 'hourPillar'), '甲子');
+});
+
+test('SM-04 23:30 switch00 is 亥 and same-day pillar', async () => {
+  const result = calculator.calculateFortune(2023, 6, 15, 23, 30, { shiMode: SHI_MODE.SWITCH_00 });
+  assert.strictEqual(result.hourPillar.branch, '亥');
+  assert.strictEqual(pillar(result, 'dayPillar'), '甲辰');
+  assert.strictEqual(pillar(result, 'hourPillar'), '乙亥');
+});
+
+test('SM-05 00:30 switch00 is 子 and same-day pillar', async () => {
+  const result = calculator.calculateFortune(2023, 6, 15, 0, 30, { shiMode: SHI_MODE.SWITCH_00 });
+  assert.strictEqual(result.hourPillar.branch, '子');
+  assert.strictEqual(pillar(result, 'dayPillar'), '甲辰');
+});
+
+test('SM-06 22:30 switch00 is 亥 and same-day pillar', async () => {
+  const result = calculator.calculateFortune(2023, 6, 15, 22, 30, { shiMode: SHI_MODE.SWITCH_00 });
+  assert.strictEqual(result.hourPillar.branch, '亥');
+  assert.strictEqual(pillar(result, 'dayPillar'), '甲辰');
+  assert.strictEqual(pillar(result, 'hourPillar'), '乙亥');
+});
+
+test('SM-07 01:30 switch23 is 丑 and same-day pillar', async () => {
+  const result = calculator.calculateFortune(2023, 6, 15, 1, 30, { shiMode: SHI_MODE.SWITCH_23 });
+  assert.strictEqual(result.hourPillar.branch, '丑');
+  assert.strictEqual(pillar(result, 'dayPillar'), '甲辰');
+  assert.strictEqual(pillar(result, 'hourPillar'), '乙丑');
+});
+
+test('SM-08 01:30 switch00 is 子 and same-day pillar', async () => {
+  const result = calculator.calculateFortune(2023, 6, 15, 1, 30, { shiMode: SHI_MODE.SWITCH_00 });
+  assert.strictEqual(result.hourPillar.branch, '子');
+  assert.strictEqual(pillar(result, 'dayPillar'), '甲辰');
+  assert.strictEqual(pillar(result, 'hourPillar'), '甲子');
+});
+
+test('ST-02 no correction, non-23h matches V1.0 pillars', async () => {
+  const noon = calculator.calculateFortune(2023, 6, 15, 12, 0);
+  assert.strictEqual(pillar(noon, 'yearPillar'), '癸卯');
+  assert.strictEqual(pillar(noon, 'monthPillar'), '戊午');
+  assert.strictEqual(pillar(noon, 'dayPillar'), '甲辰');
+  assert.strictEqual(pillar(noon, 'hourPillar'), '庚午');
+
+  const morning = calculator.calculateFortune(2023, 6, 15, 8, 30, { shiMode: DEFAULT_SHI_MODE });
+  assert.strictEqual(pillar(morning, 'yearPillar'), '癸卯');
+  assert.strictEqual(pillar(morning, 'monthPillar'), '戊午');
+  assert.strictEqual(pillar(morning, 'dayPillar'), '甲辰');
+  assert.strictEqual(pillar(morning, 'hourPillar'), '戊辰');
+});
+
+test('resolveDayPillarDate boundaries 22/23/0/1 x both modes', async () => {
+  const cases = [
+    { hour: 22, mode: SHI_MODE.SWITCH_23, expected: BASE },
+    { hour: 23, mode: SHI_MODE.SWITCH_23, expected: { year: 2023, month: 6, day: 16 } },
+    { hour: 0, mode: SHI_MODE.SWITCH_23, expected: BASE },
+    { hour: 1, mode: SHI_MODE.SWITCH_23, expected: BASE },
+    { hour: 22, mode: SHI_MODE.SWITCH_00, expected: BASE },
+    { hour: 23, mode: SHI_MODE.SWITCH_00, expected: BASE },
+    { hour: 0, mode: SHI_MODE.SWITCH_00, expected: BASE },
+    { hour: 1, mode: SHI_MODE.SWITCH_00, expected: BASE },
+  ];
+
+  for (const c of cases) {
+    const actual = calculator.resolveDayPillarDate(BASE.year, BASE.month, BASE.day, c.hour, c.mode);
+    assert.deepStrictEqual(actual, c.expected, `${c.mode} hour=${c.hour}`);
+  }
+
+  const yearWrap = calculator.resolveDayPillarDate(2023, 12, 31, 23, SHI_MODE.SWITCH_23);
+  assert.deepStrictEqual(yearWrap, { year: 2024, month: 1, day: 1 });
+});
+
+test('ST-03 year/month pillars at solar-term boundary use JST epoch, not OS TZ', async () => {
+  const mangzhongIso = '2023-06-07T03:00:00+09:00';
+  const risshunIso = '2023-02-05T11:00:00+09:00';
+  const mangzhongEpoch = DateUtils.parseISOString(mangzhongIso).getTime();
+  const risshunEpoch = DateUtils.parseISOString(risshunIso).getTime();
+
+  const beforeMangzhong = DateUtils.toJstEpochMillis(2023, 6, 7, 2, 59);
+  const atMangzhong = DateUtils.toJstEpochMillis(2023, 6, 7, 3, 0);
+  assert.ok(beforeMangzhong < mangzhongEpoch, '02:59 must be before 芒種 epoch');
+  assert.strictEqual(atMangzhong, mangzhongEpoch, '03:00 must equal 芒種 ISO epoch');
+
+  const beforeMangzhongFortune = calculator.calculateFortune(2023, 6, 7, 2, 59);
+  const atMangzhongFortune = calculator.calculateFortune(2023, 6, 7, 3, 0);
+  assert.strictEqual(beforeMangzhongFortune.monthPillar.branch, '巳');
+  assert.strictEqual(pillar(beforeMangzhongFortune, 'monthPillar'), '丁巳');
+  assert.strictEqual(atMangzhongFortune.monthPillar.branch, '午');
+  assert.strictEqual(pillar(atMangzhongFortune, 'monthPillar'), '戊午');
+
+  const beforeRisshun = DateUtils.toJstEpochMillis(2023, 2, 5, 10, 59);
+  const atRisshun = DateUtils.toJstEpochMillis(2023, 2, 5, 11, 0);
+  assert.ok(beforeRisshun < risshunEpoch);
+  assert.strictEqual(atRisshun, risshunEpoch);
+
+  const beforeRisshunFortune = calculator.calculateFortune(2023, 2, 5, 10, 59);
+  const atRisshunFortune = calculator.calculateFortune(2023, 2, 5, 11, 0);
+  assert.strictEqual(pillar(beforeRisshunFortune, 'yearPillar'), '壬寅');
+  assert.strictEqual(pillar(atRisshunFortune, 'yearPillar'), '癸卯');
+  assert.strictEqual(beforeRisshunFortune.monthPillar.branch, '丑');
+  assert.strictEqual(atRisshunFortune.monthPillar.branch, '寅');
+});

--- a/chrome-extension/tests/core/FortuneCalculator.shiMode.test.js
+++ b/chrome-extension/tests/core/FortuneCalculator.shiMode.test.js
@@ -117,6 +117,23 @@ test('ST-02 no correction, non-23h matches V1.0 pillars', async () => {
   assert.strictEqual(pillar(morning, 'hourPillar'), '戊辰');
 });
 
+test('year/month pillar APIs reject invalid calendar dates', async () => {
+  await assert.throws(
+    async () => {
+      calculator.calculateYearPillarWithDate(2023, 2, 30, 12, 0);
+    },
+    '無効な日付',
+    'year pillar should reject February 30'
+  );
+  await assert.throws(
+    async () => {
+      calculator.calculateMonthPillar(2023, 2, 30, 12, 0);
+    },
+    '無効な日付',
+    'month pillar should reject February 30'
+  );
+});
+
 test('resolveDayPillarDate boundaries 22/23/0/1 x both modes', async () => {
   const cases = [
     { hour: 22, mode: SHI_MODE.SWITCH_23, expected: BASE },

--- a/chrome-extension/tests/core/FortuneCalculator.test.js
+++ b/chrome-extension/tests/core/FortuneCalculator.test.js
@@ -54,6 +54,7 @@ test('FortuneCalculator.calculateFortune returns correct structure', async () =>
 });
 
 test('FortuneCalculator.calculateFortune handles standard date (2023-06-15)', async () => {
+    // ST-02: 補正なし・非23時台は V1.0 と同じ柱
     // 2023-06-15 12:00
     // 2023 (癸卯), 6月 (芒種後 -> 戊午), 15日
     const result = await calculator.calculateFortune(2023, 6, 15, 12, 0);


### PR DESCRIPTION
## Summary
- `FortuneCalculator`に`switch23` / `switch00`の子時モードを追加
- `resolveDayPillarDate`を導入し、人工的な翌日扱いを日柱・時干のみに限定
- 年柱・月柱の節入り比較をJST epochへ統一
- SM-01〜08、ST-02、ST-03、境界ケースのテストを追加
- レビューで判明した不正日付の正規化を修正し、APIの入力検証を維持

## Test plan
- [x] `node chrome-extension/tests/run_tests.js`（56 passed, 0 failed）
- [x] UTC+14環境で全テスト（56 passed, 0 failed）
- [x] 変更ファイルのLint確認（エラーなし）
- [x] 2023-02-30の年柱・月柱APIが`InvalidDateError`になることを確認

Made with [Cursor](https://cursor.com)