### PR TITLE
feat: implement P3 great-fortune time-of-day support

### DIFF
--- a/chrome-extension/docs/design/時刻補正機能_詳細設計/11_実装タスクリスト_フェーズ計画.md
+++ b/chrome-extension/docs/design/時刻補正機能_詳細設計/11_実装タスクリスト_フェーズ計画.md
@@ -122,19 +122,19 @@
 
 ### 実装タスク
 
-- [ ] P3-1 `calculateStartAge` に `birthHour` / `birthMinute` 追加
-- [ ] P3-2 `_getNextSolarTerm` / `_getPreviousSolarTerm` に時分追加（正午固定廃止）
-- [ ] P3-3 節探索の前後判定は epoch 比較。立運距離は **`getElapsedDays`（小数日）/ 3 → round/ceil**
-- [ ] P3-4 `calculateCycles` から時分を伝播
-- [ ] P3-5 呼び出し側（この時点ではテスト／後続P5）の互換を確認
+- [x] P3-1 `calculateStartAge` に `birthHour` / `birthMinute` 追加
+- [x] P3-2 `_getNextSolarTerm` / `_getPreviousSolarTerm` に時分追加（正午固定廃止）
+- [x] P3-3 節探索の前後判定は epoch 比較。立運距離は **`getElapsedDays`（小数日）/ 3 → round/ceil**
+- [x] P3-4 `calculateCycles` から時分を伝播
+- [x] P3-5 呼び出し側（この時点ではテスト／後続P5）の互換を確認
 
 ### テスト（必須）
 
-- [ ] P3-T1 **GF-02**（時分がAPIに渡り正午固定でない）
-- [ ] P3-T2 **GF-01**（次節/前節は同一、時分差で `elapsedDays/3` の丸め境界を跨ぎ開始年齢が変わる）
-- [ ] P3-T3 **GF-03**（23時台でも立運は渡した当日基準＝子時+1日を使わない）
-- [ ] P3-T4 **GF-04**（epoch差がTZ非依存、かつ小数日を保持。暦日整数差と一致しないこと）
-- [ ] P3-T5 既存 GreatFortune テストを新シグネチャへ更新しグリーン
+- [x] P3-T1 **GF-02**（時分がAPIに渡り正午固定でない）
+- [x] P3-T2 **GF-01**（次節/前節は同一、時分差で `elapsedDays/3` の丸め境界を跨ぎ開始年齢が変わる）
+- [x] P3-T3 **GF-03**（23時台でも立運は渡した当日基準＝子時+1日を使わない）
+- [x] P3-T4 **GF-04**（epoch差がTZ非依存、かつ小数日を保持。暦日整数差と一致しないこと）
+- [x] P3-T5 既存 GreatFortune テストを新シグネチャへ更新しグリーン
 - [ ] **ST-01 はP5**（補正×節入り跨ぎの年月柱は統合テスト）
 
 ### 完了ゲート

--- a/chrome-extension/js/core/GreatFortuneCalculator.js
+++ b/chrome-extension/js/core/GreatFortuneCalculator.js
@@ -114,31 +114,27 @@ export class GreatFortuneCalculator {
    * @param {number} year - 生年
    * @param {number} month - 生月
    * @param {number} day - 生日
+   * @param {number} hour - 生時
+   * @param {number} minute - 生分
    * @returns {Date} 次の節入り時刻
    * @private
    */
-  _getNextSolarTerm(year, month, day) {
-    const birthDate = DateUtils.createDate(year, month, day, 12, 0);
+  _getNextSolarTerm(year, month, day, hour, minute) {
+    const birthEpoch = DateUtils.createDate(year, month, day, hour, minute).getTime();
 
-    // 節気の順序（1月の小寒から12月の大雪まで日付順）
-    // Note: getSolarTermDateTime returns the date in the specified year.
-    // 小寒 is in Jan, 立春 is in Feb, ..., 大雪 is in Dec.
     const solarTerms = [
       '小寒', '立春', '啓蟄', '清明', '立夏', '芒種', '小暑',
       '立秋', '白露', '寒露', '立冬', '大雪'
     ];
 
-    // 現在の年の全節気をチェック
     for (const termName of solarTerms) {
       const termDt = this.fortuneCalc.getSolarTermDateTime(year, termName);
-      if (termDt > birthDate) {
+      if (termDt.getTime() > birthEpoch) {
         return termDt;
       }
     }
 
-    // 現在の年の節気がすべて過去の場合、次の年の立春を返す
-    const nextYearRisshun = this.fortuneCalc.getSolarTermDateTime(year + 1, '立春');
-    return nextYearRisshun;
+    return this.fortuneCalc.getSolarTermDateTime(year + 1, '立春');
   }
 
   /**
@@ -147,29 +143,27 @@ export class GreatFortuneCalculator {
    * @param {number} year - 生年
    * @param {number} month - 生月
    * @param {number} day - 生日
+   * @param {number} hour - 生時
+   * @param {number} minute - 生分
    * @returns {Date} 前の節入り時刻
    * @private
    */
-  _getPreviousSolarTerm(year, month, day) {
-    const birthDate = DateUtils.createDate(year, month, day, 12, 0);
+  _getPreviousSolarTerm(year, month, day, hour, minute) {
+    const birthEpoch = DateUtils.createDate(year, month, day, hour, minute).getTime();
 
-    // 節気の順序（12月の大雪から1月の小寒まで日付逆順）
     const solarTerms = [
       '大雪', '立冬', '寒露', '白露', '立秋', '小暑',
       '芒種', '立夏', '清明', '啓蟄', '立春', '小寒'
     ];
 
-    // 現在の年の全節気を逆順にチェック
     for (const termName of solarTerms) {
       const termDt = this.fortuneCalc.getSolarTermDateTime(year, termName);
-      if (termDt < birthDate) {
+      if (termDt.getTime() < birthEpoch) {
         return termDt;
       }
     }
 
-    // 現在の年の節気がすべて未来の場合、前の年の小寒を返す
-    const prevYearShokan = this.fortuneCalc.getSolarTermDateTime(year - 1, '小寒');
-    return prevYearShokan;
+    return this.fortuneCalc.getSolarTermDateTime(year - 1, '小寒');
   }
 
   /**
@@ -178,45 +172,66 @@ export class GreatFortuneCalculator {
    * @param {number} birthYear - 生年
    * @param {number} birthMonth - 生月
    * @param {number} birthDay - 生日
+   * @param {number} birthHour - 生時（時刻なしのときは呼び出し側が 12 を渡す）
+   * @param {number} birthMinute - 生分
    * @param {string} gender - 性別（"男性" or "女性"）
    * @param {string} roundingMethod - 端数処理方法（"round": 四捨五入、"ceil": 切り上げ）
    * @returns {number} 開始年齢（整数、0〜10歳）
    * @throws {InvalidDateError} 日付または性別が不正な場合
    * @throws {CalculationError} 計算中にエラーが発生した場合
    */
-  calculateStartAge(birthYear, birthMonth, birthDay, gender, roundingMethod = 'round') {
-    let birthDate;
+  calculateStartAge(
+    birthYear,
+    birthMonth,
+    birthDay,
+    birthHour,
+    birthMinute,
+    gender,
+    roundingMethod = 'round'
+  ) {
+    let birthInstant;
     try {
-      // 生年月日のDateオブジェクトを作成
-      birthDate = DateUtils.createDate(birthYear, birthMonth, birthDay, 12, 0);
+      birthInstant = DateUtils.createDate(
+        birthYear,
+        birthMonth,
+        birthDay,
+        birthHour,
+        birthMinute
+      );
     } catch (e) {
-      throw new InvalidDateError(`無効な日付です: ${birthYear}/${birthMonth}/${birthDay} - ${e.message}`);
+      throw new InvalidDateError(
+        `無効な日付です: ${birthYear}/${birthMonth}/${birthDay} ${birthHour}:${birthMinute} - ${e.message}`
+      );
     }
 
-    // 順行/逆行の判定
     const isForward = this.isForwardProgression(birthYear, gender);
 
-    // 次の節入り時刻を取得
-    let nextTermDt;
+    let termInstant;
     try {
       if (isForward) {
-        // 順行: 生日の次の節入り時刻
-        nextTermDt = this._getNextSolarTerm(birthYear, birthMonth, birthDay);
+        termInstant = this._getNextSolarTerm(
+          birthYear,
+          birthMonth,
+          birthDay,
+          birthHour,
+          birthMinute
+        );
       } else {
-        // 逆行: 生日の前の節入り時刻
-        nextTermDt = this._getPreviousSolarTerm(birthYear, birthMonth, birthDay);
+        termInstant = this._getPreviousSolarTerm(
+          birthYear,
+          birthMonth,
+          birthDay,
+          birthHour,
+          birthMinute
+        );
       }
     } catch (e) {
       throw new CalculationError(`節入り時刻の取得に失敗しました: ${e.message}`);
     }
 
-    // 日数を計算
-    const deltaDays = Math.abs(DateUtils.getDaysDifference(birthDate, nextTermDt));
+    const elapsedDays = Math.abs(DateUtils.getElapsedDays(birthInstant, termInstant));
+    const ageFloat = elapsedDays / 3.0;
 
-    // 日数を3で割って年齢を算出
-    const ageFloat = deltaDays / 3.0;
-
-    // 端数処理
     let age;
     if (roundingMethod === 'round') {
       age = Math.round(ageFloat);
@@ -228,10 +243,7 @@ export class GreatFortuneCalculator {
       );
     }
 
-    // 0〜10歳の範囲に制限
-    age = Math.max(0, Math.min(10, age));
-
-    return age;
+    return Math.max(0, Math.min(10, age));
   }
 
   /**
@@ -271,6 +283,8 @@ export class GreatFortuneCalculator {
       birthYear,
       birthMonth,
       birthDay,
+      birthHour,
+      birthMinute,
       gender,
       roundingMethod
     );

--- a/chrome-extension/tests/core/GreatFortuneCalculator.test.js
+++ b/chrome-extension/tests/core/GreatFortuneCalculator.test.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { FortuneCalculator } from '../../js/core/FortuneCalculator.js';
 import { GreatFortuneCalculator } from '../../js/core/GreatFortuneCalculator.js';
+import { DateUtils } from '../../js/utils/dateUtils.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = path.resolve(__dirname, '../../data');
@@ -35,20 +36,16 @@ test('GreatFortuneCalculator.initialize', async () => {
 });
 
 test('GreatFortuneCalculator.calculateStartAge', async () => {
-    // 2023-06-15, Male
-    const age = greatFortuneCalc.calculateStartAge(2023, 6, 15, '男性');
+    // 2023-06-15 12:00, Male（V1.0 と同じ正午ケース）
+    const age = greatFortuneCalc.calculateStartAge(2023, 6, 15, 12, 0, '男性');
 
-    // Debug info
     const isForward = greatFortuneCalc.isForwardProgression(2023, '男性');
-    // We can't easily access private method _getPreviousSolarTerm directly unless we modify visibility or use reflection, 
-    // but in JS valid to call private methods if not enforced by private fields #.
-    // However, methods are likely accessible.
     const term = isForward ?
-        greatFortuneCalc._getNextSolarTerm(2023, 6, 15) :
-        greatFortuneCalc._getPreviousSolarTerm(2023, 6, 15);
+        greatFortuneCalc._getNextSolarTerm(2023, 6, 15, 12, 0) :
+        greatFortuneCalc._getPreviousSolarTerm(2023, 6, 15, 12, 0);
 
-    const birthDate = new Date(2023, 5, 15, 12, 0);
-    const diff = (birthDate - term) / (1000 * 60 * 60 * 24);
+    const birthDate = DateUtils.createDate(2023, 6, 15, 12, 0);
+    const diff = DateUtils.getElapsedDays(birthDate, term);
 
     console.log(`    DEBUG: 2023-06-15 Male. IsForward: ${isForward}`);
     console.log(`    DEBUG: Term Date: ${term.toISOString()}`);

--- a/chrome-extension/tests/core/GreatFortuneCalculator.timeCorrection.test.js
+++ b/chrome-extension/tests/core/GreatFortuneCalculator.timeCorrection.test.js
@@ -1,0 +1,110 @@
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { FortuneCalculator } from '../../js/core/FortuneCalculator.js';
+import { GreatFortuneCalculator } from '../../js/core/GreatFortuneCalculator.js';
+import { DateUtils } from '../../js/utils/dateUtils.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = path.resolve(__dirname, '../../data');
+
+class MockDataLoader {
+  constructor(basePath) {
+    this.basePath = basePath;
+  }
+
+  async loadJSON(filename) {
+    return JSON.parse(fs.readFileSync(path.join(this.basePath, filename), 'utf8'));
+  }
+
+  async loadSolarTerms() {
+    return this.loadJSON('solar_terms.json');
+  }
+
+  async loadStemBranchMaster() {
+    return this.loadJSON('stem_branch_master.json');
+  }
+}
+
+let calc;
+
+test('GreatFortune time-correction tests initialize', async () => {
+  const fortuneCalc = new FortuneCalculator(new MockDataLoader(DATA_DIR));
+  await fortuneCalc.initialize();
+  calc = new GreatFortuneCalculator(fortuneCalc);
+  await calc.initialize();
+  assert.strictEqual(calc.isForwardProgression(2023, '男性'), false, '2023 male is reverse');
+});
+
+test('GF-02 calculateStartAge receives hour/minute and is not noon-fixed', async () => {
+  const beforeMangzhong = calc._getPreviousSolarTerm(2023, 6, 7, 0, 0);
+  const afterMangzhong = calc._getPreviousSolarTerm(2023, 6, 7, 12, 0);
+  const mangzhong = DateUtils.parseISOString('2023-06-07T03:00:00+09:00');
+  const lixia = DateUtils.parseISOString('2023-05-07T09:00:00+09:00');
+
+  assert.strictEqual(beforeMangzhong.getTime(), lixia.getTime(), '00:00 is before 芒種 so previous is 立夏');
+  assert.strictEqual(afterMangzhong.getTime(), mangzhong.getTime(), '12:00 is after 芒種 so previous is 芒種');
+
+  const ageMidnight = calc.calculateStartAge(2023, 6, 7, 0, 0, '男性');
+  const ageNoon = calc.calculateStartAge(2023, 6, 7, 12, 0, '男性');
+  assert.ok(ageMidnight !== ageNoon, 'start age must change when hour/minute change on the same calendar day');
+});
+
+test('GF-01 same solar term, time-of-day crosses elapsedDays/3 rounding boundary', async () => {
+  const term = calc._getPreviousSolarTerm(2023, 6, 14, 12, 0);
+  const noonBirth = DateUtils.createDate(2023, 6, 14, 12, 0);
+  const afternoonBirth = DateUtils.createDate(2023, 6, 14, 15, 0);
+
+  assert.strictEqual(
+    calc._getPreviousSolarTerm(2023, 6, 14, 15, 0).getTime(),
+    term.getTime(),
+    'both times share the same previous term'
+  );
+
+  const noonElapsed = Math.abs(DateUtils.getElapsedDays(noonBirth, term));
+  const afternoonElapsed = Math.abs(DateUtils.getElapsedDays(afternoonBirth, term));
+  assert.strictEqual(Math.round(noonElapsed / 3), 2);
+  assert.strictEqual(Math.round(afternoonElapsed / 3), 3);
+
+  const calendarDaysNoon = Math.abs(DateUtils.getCalendarDaysDifference(noonBirth, term));
+  const calendarDaysAfternoon = Math.abs(DateUtils.getCalendarDaysDifference(afternoonBirth, term));
+  assert.strictEqual(calendarDaysNoon, calendarDaysAfternoon, 'calendar-day distance is unchanged');
+  assert.strictEqual(
+    Math.round(calendarDaysNoon / 3),
+    Math.round(calendarDaysAfternoon / 3),
+    'calendar-day rounding would not change the start age'
+  );
+
+  const ageNoon = calc.calculateStartAge(2023, 6, 14, 12, 0, '男性');
+  const ageAfternoon = calc.calculateStartAge(2023, 6, 14, 15, 0, '男性');
+  assert.strictEqual(ageNoon, 2);
+  assert.strictEqual(ageAfternoon, 3);
+});
+
+test('GF-03 23:00 uses the given calendar day, not shi-mode next day', async () => {
+  const ageAt23 = calc.calculateStartAge(2023, 6, 13, 23, 0, '男性');
+  const ageIfNextDay = calc.calculateStartAge(2023, 6, 14, 23, 0, '男性');
+  assert.strictEqual(ageAt23, 2);
+  assert.strictEqual(ageIfNextDay, 3);
+  assert.ok(ageAt23 !== ageIfNextDay, 'using next day would change start age');
+
+  const term = calc._getPreviousSolarTerm(2023, 6, 13, 23, 0);
+  const birth = DateUtils.createDate(2023, 6, 13, 23, 0);
+  const elapsed = Math.abs(DateUtils.getElapsedDays(birth, term));
+  assert.strictEqual(Math.round(elapsed / 3), 2);
+});
+
+test('GF-04 elapsed days are TZ-independent fractional days, not calendar integers', async () => {
+  const birth = DateUtils.createDate(2023, 6, 15, 12, 0);
+  const term = calc._getPreviousSolarTerm(2023, 6, 15, 12, 0);
+  const elapsed = DateUtils.getElapsedDays(birth, term);
+  const calendar = DateUtils.getCalendarDaysDifference(birth, term);
+  const epochElapsed = (term.getTime() - birth.getTime()) / 86400000;
+
+  assert.strictEqual(elapsed, epochElapsed);
+  assert.ok(elapsed !== Math.trunc(elapsed), 'fractional days must be kept');
+  assert.ok(Math.abs(elapsed) !== Math.abs(calendar), 'must not equal calendar-day integer difference');
+
+  const age = calc.calculateStartAge(2023, 6, 15, 12, 0, '男性');
+  assert.strictEqual(age, Math.max(0, Math.min(10, Math.round(Math.abs(elapsed) / 3))));
+});


### PR DESCRIPTION
## Summary
- 大運開始年齢計算に出生時刻（時・分）を追加
- 節入りの前後判定をJST epochで行い、正午固定を廃止
- 立運距離を`getElapsedDays`の小数日で計算し、時分を反映
- 子時の人工的な翌日扱いを大運へ適用しないことをテスト
- GF-01〜04と既存大運テストを追加・更新

## Test plan
- [x] `node chrome-extension/tests/run_tests.js`（61 passed, 0 failed）
- [x] UTC+14環境で全テスト（61 passed, 0 failed）
- [x] 変更ファイルのLint確認（エラーなし）
- [x] 差分の形式チェック

## Follow-up
- 時刻未入力時は、P5のAppController配線で入力年月日12:00を明示的に渡す（設計上、Calculator内では欠損を推測しない）。

Made with [Cursor](https://cursor.com)