### PR TITLE
feat: implement P5 time-correction app wiring

### DIFF
--- a/chrome-extension/docs/design/時刻補正機能_詳細設計/11_実装タスクリスト_フェーズ計画.md
+++ b/chrome-extension/docs/design/時刻補正機能_詳細設計/11_実装タスクリスト_フェーズ計画.md
@@ -184,26 +184,26 @@
 
 ### 実装タスク
 
-- [ ] P5-1 初期化でマスタ読込 → `TimeCorrectionService` 生成 → 都道府県セレクト埋込
-- [ ] P5-2 `handleCalculate` で補正 → `t_corrected` を Fortune / GreatFortune へ
-- [ ] P5-3 `shiMode` を `calculateFortune` へ渡す
-- [ ] P5-4 表示年は補正適用時 `t_corrected.year`
-- [ ] P5-5 時刻なし経路
+- [x] P5-1 初期化でマスタ読込 → `TimeCorrectionService` 生成 → 都道府県セレクト埋込
+- [x] P5-2 `handleCalculate` で補正 → `t_corrected` を Fortune / GreatFortune へ
+- [x] P5-3 `shiMode` を `calculateFortune` へ渡す
+- [x] P5-4 表示年は補正適用時 `t_corrected.year`
+- [x] P5-5 時刻なし経路
   - 補正スキップ・時柱なし
   - 大運は **入力年月日 12:00**
-- [ ] P5-6 `ResultRenderer.showResults(..., displayYear, { correction, shiMode })` を呼び出す（**API拡張と配線**。サマリDOMの完成はP6）
+- [x] P5-6 `ResultRenderer.showResults(..., displayYear, { correction, shiMode })` を呼び出す（**API拡張と配線**。サマリDOMの完成はP6）
 
 ### テスト（必須）
 
-- [ ] P5-T1 **IX-01〜04**（補正×子時の合成境界。`08` の表どおり）
-- [ ] P5-T2 時刻なし経路
+- [x] P5-T1 **IX-01〜04**（補正×子時の合成境界。`08` の表どおり）
+- [x] P5-T2 時刻なし経路
   - 時柱 null、`applied: false`
   - 大運引数が入力年月日 **12:00** であること
-- [ ] P5-T3 補正あり経路で Fortune と GreatFortune に同じ `t_corrected` が渡ること
-- [ ] P5-T4 **ST-01**（補正で節入りを跨ぐ年月柱）
-- [ ] P5-T5 節気データ範囲外の入力で既存エラーが表示されること
-- [ ] P5-T6 経度マスタ欠落・破損時の初期化/計算エラー
-- [ ] P5-T7 P0〜P4 既存自動テスト継続グリーン
+- [x] P5-T3 補正あり経路で Fortune と GreatFortune に同じ `t_corrected` が渡ること
+- [x] P5-T4 **ST-01**（補正で節入りを跨ぐ年月柱）
+- [x] P5-T5 節気データ範囲外の入力で既存エラーが表示されること
+- [x] P5-T6 経度マスタ欠落・破損時の初期化/計算エラー
+- [x] P5-T7 P0〜P4 既存自動テスト継続グリーン
 
 ### 完了ゲート
 

--- a/chrome-extension/js/app/AppController.js
+++ b/chrome-extension/js/app/AppController.js
@@ -6,22 +6,23 @@ import { FortuneCalculator } from "../core/FortuneCalculator.js";
 import { GreatFortuneCalculator } from "../core/GreatFortuneCalculator.js";
 import { JuuniunCalculator } from "../core/JuuniunCalculator.js";
 import { TsuuhenCalculator } from "../core/TsuuhenCalculator.js";
+import { TimeCorrectionService } from "../core/TimeCorrectionService.js";
 import { FormRenderer } from "../ui/FormRenderer.js";
 import { ResultRenderer } from "../ui/ResultRenderer.js";
 import { ImageExporter } from "../ui/ImageExporter.js";
 import { InputManager } from "./InputManager.js";
 
 export class AppController {
-    constructor() {
-        this.dataLoader = null;
-        this.fortuneCalculator = null;
-        this.greatFortuneCalculator = null;
-        this.juuniunCalculator = null;
-        this.tsuuhenCalculator = null;
-
-        this.formRenderer = null;
-        this.resultRenderer = null;
-        this.inputManager = null;
+    constructor(options = {}) {
+        this.formRenderer = options.formRenderer ?? null;
+        this.resultRenderer = options.resultRenderer ?? null;
+        this.inputManager = options.inputManager ?? null;
+        this.dataLoader = options.dataLoader ?? null;
+        this.fortuneCalculator = options.fortuneCalculator ?? null;
+        this.greatFortuneCalculator = options.greatFortuneCalculator ?? null;
+        this.juuniunCalculator = options.juuniunCalculator ?? null;
+        this.tsuuhenCalculator = options.tsuuhenCalculator ?? null;
+        this.timeCorrectionService = options.timeCorrectionService ?? null;
 
         this.initialized = false;
     }
@@ -33,29 +34,29 @@ export class AppController {
         try {
             console.log("Initializing application...");
 
-            // UIコンポーネントの初期化
-            this.formRenderer = new FormRenderer();
-            this.resultRenderer = new ResultRenderer();
-            this.inputManager = new InputManager(this.formRenderer);
+            this.formRenderer = this.formRenderer ?? new FormRenderer();
+            this.resultRenderer = this.resultRenderer ?? new ResultRenderer();
+            this.inputManager = this.inputManager ?? new InputManager(this.formRenderer);
+            this.dataLoader = this.dataLoader ?? new DataLoader();
 
-            // DataLoader初期化
-            this.dataLoader = new DataLoader();
+            const master = await this.dataLoader.loadPrefectureLongitude();
+            this.timeCorrectionService = this.timeCorrectionService ?? new TimeCorrectionService(master);
+            this.formRenderer.populatePrefectures(master);
+            this.inputManager.setLongitudeMaster(master);
 
-            // 計算エンジンの初期化
-            this.fortuneCalculator = new FortuneCalculator(this.dataLoader);
+            this.fortuneCalculator = this.fortuneCalculator ?? new FortuneCalculator(this.dataLoader);
             await this.fortuneCalculator.initialize();
 
-            this.greatFortuneCalculator = new GreatFortuneCalculator(
+            this.greatFortuneCalculator = this.greatFortuneCalculator ?? new GreatFortuneCalculator(
                 this.fortuneCalculator
             );
             await this.greatFortuneCalculator.initialize();
 
-            this.juuniunCalculator = new JuuniunCalculator(this.dataLoader);
+            this.juuniunCalculator = this.juuniunCalculator ?? new JuuniunCalculator(this.dataLoader);
             await this.juuniunCalculator.initialize();
 
-            this.tsuuhenCalculator = new TsuuhenCalculator();
+            this.tsuuhenCalculator = this.tsuuhenCalculator ?? new TsuuhenCalculator();
 
-            // イベントリスナーのセットアップ
             this.setupEventListeners();
 
             this.initialized = true;
@@ -63,9 +64,14 @@ export class AppController {
 
         } catch (error) {
             console.error("Initialization error:", error);
-            this.formRenderer.showError(
-                "アプリケーションの初期化に失敗しました: " + error.message
-            );
+            this.initialized = false;
+            if (this.formRenderer && typeof this.formRenderer.showError === "function") {
+                this.formRenderer.showError(
+                    "アプリケーションの初期化に失敗しました: " + error.message
+                );
+            } else {
+                throw error;
+            }
         }
     }
 
@@ -73,86 +79,112 @@ export class AppController {
      * イベントリスナーのセットアップ
      */
     setupEventListeners() {
-        // 計算実行
         this.formRenderer.onSubmit(this.handleCalculate.bind(this));
-
-        // クリア
         this.formRenderer.onClear(this.handleClear.bind(this));
-
-        // クリップボード貼り付け
         this.formRenderer.onPaste(this.handlePaste.bind(this));
-
-        // PNG保存
         this.resultRenderer.onSavePNG(this.handleSavePNG.bind(this));
+    }
+
+    /**
+     * 入力から命式・大運を計算する（UI非依存）
+     */
+    runCalculation(input) {
+        let correction;
+        let fortune;
+        let cycles;
+        let displayYear;
+        const shiMode = input.shiMode;
+
+        if (input.hour == null) {
+            correction = { applied: false, reason: "no_time" };
+            fortune = this.fortuneCalculator.calculateFortune(
+                input.year,
+                input.month,
+                input.day,
+                null,
+                null,
+                { shiMode }
+            );
+            cycles = this.greatFortuneCalculator.calculateCycles(
+                input.year,
+                input.month,
+                input.day,
+                12,
+                0,
+                input.gender
+            );
+            displayYear = input.year;
+        } else {
+            correction = this.timeCorrectionService.correct({
+                year: input.year,
+                month: input.month,
+                day: input.day,
+                hour: input.hour,
+                minute: input.minute,
+                prefectureCode: input.prefectureCode,
+                offsetMinutes: input.offsetMinutes,
+            });
+            const { year: y, month: m, day: d, hour: h, minute: mi } = correction.corrected;
+            fortune = this.fortuneCalculator.calculateFortune(
+                y, m, d, h, mi, { shiMode }
+            );
+            cycles = this.greatFortuneCalculator.calculateCycles(
+                y, m, d, h, mi, input.gender
+            );
+            displayYear = y;
+        }
+
+        const juuniunResults = this.juuniunCalculator.calculateForPillars(
+            fortune.dayPillar.stem,
+            fortune.yearPillar.branch,
+            fortune.monthPillar.branch,
+            fortune.dayPillar.branch,
+            fortune.hourPillar ? fortune.hourPillar.branch : null
+        );
+
+        const tsuuhenResults = this.tsuuhenCalculator.calculateForPillars(
+            fortune.dayPillar.stem,
+            fortune.yearPillar.stem,
+            fortune.monthPillar.stem,
+            fortune.hourPillar ? fortune.hourPillar.stem : null
+        );
+
+        return {
+            fortune,
+            juuniunResults,
+            tsuuhenResults,
+            cycles,
+            displayYear,
+            correction,
+            shiMode,
+        };
     }
 
     /**
      * 計算ハンドラ
      */
     async handleCalculate() {
-        console.time('calculation');
+        console.time("calculation");
         try {
             this.formRenderer.hideError();
 
-            // 入力取得と検証
             const inputData = this.inputManager.getFormInput();
+            const result = this.runCalculation(inputData);
 
-            console.log("Input data:", inputData);
-
-            // 1. 命式計算
-            const fortune = await this.fortuneCalculator.calculateFortune(
-                inputData.year,
-                inputData.month,
-                inputData.day,
-                inputData.hour,
-                inputData.minute
-            );
-            console.log("Fortune calculated:", fortune);
-
-            // 2. 十二運計算
-            const juuniunResults = this.juuniunCalculator.calculateForPillars(
-                fortune.dayPillar.stem,
-                fortune.yearPillar.branch,
-                fortune.monthPillar.branch,
-                fortune.dayPillar.branch,
-                fortune.hourPillar ? fortune.hourPillar.branch : null
-            );
-            console.log("Juuniun calculated:", juuniunResults);
-
-            // 3. 通変星計算
-            const tsuuhenResults = this.tsuuhenCalculator.calculateForPillars(
-                fortune.dayPillar.stem,
-                fortune.yearPillar.stem,
-                fortune.monthPillar.stem,
-                fortune.hourPillar ? fortune.hourPillar.stem : null
-            );
-            console.log("Tsuuhen calculated:", tsuuhenResults);
-
-            // 4. 大運計算
-            const greatFortuneCycles = this.greatFortuneCalculator.calculateCycles(
-                inputData.year,
-                inputData.month,
-                inputData.day,
-                inputData.hour,
-                inputData.minute,
-                inputData.gender
-            );
-            console.log("Great fortune cycles calculated:", greatFortuneCycles);
-
-            // 結果表示
             this.resultRenderer.showResults(
-                fortune,
-                juuniunResults,
-                tsuuhenResults,
-                greatFortuneCycles,
-                inputData.year
+                result.fortune,
+                result.juuniunResults,
+                result.tsuuhenResults,
+                result.cycles,
+                result.displayYear,
+                { correction: result.correction, shiMode: result.shiMode }
             );
 
         } catch (error) {
             console.error("Calculation error:", error);
             this.formRenderer.showError(error.message);
         } finally {
-            console.timeEnd('calculation');
+            console.timeEnd("calculation");
         }
     }
 
@@ -182,26 +214,22 @@ export class AppController {
      * PNG保存ハンドラ
      */
     async handleSavePNG() {
-        // ボタンへの参照を保持
         const saveBtn = this.resultRenderer?.elements?.savePngBtn;
 
         try {
             this.formRenderer.hideError();
 
-            // フォームの値からファイル名用の年を取得
             const inputData = this.formRenderer.getValues();
             const year = inputData.year || "unknown";
 
             const targetElement = this.resultRenderer?.elements?.resultSection;
 
-            // 要素が表示されていない場合はエラー
             if (!targetElement || targetElement.style.display === "none") {
                 throw new Error("計算結果がありません。まず計算を実行してください。");
             }
 
             const filename = ImageExporter.generateFilename("fortune", year);
 
-            // ボタンを一時的に隠す
             if (saveBtn) {
                 saveBtn.style.display = "none";
             }
@@ -212,7 +240,6 @@ export class AppController {
             console.error("Save PNG error:", error);
             this.formRenderer.showError("PNG保存に失敗しました: " + error.message);
         } finally {
-            // ボタンを確実に戻す
             if (saveBtn) {
                 saveBtn.style.display = "";
             }

--- a/chrome-extension/js/ui/ResultRenderer.js
+++ b/chrome-extension/js/ui/ResultRenderer.js
@@ -16,10 +16,18 @@ export class ResultRenderer {
 
   /**
    * 結果を表示してセクションを表示状態にする
+   * @param {object} fortune
+   * @param {object} juuniunResults
+   * @param {object} tsuuhenResults
+   * @param {Array} greatFortuneCycles
+   * @param {number} displayYear 補正適用時は t_corrected.year
+   * @param {{correction?: object, shiMode?: string}} [meta]
    */
-  showResults(fortune, juuniunResults, tsuuhenResults, greatFortuneCycles, year) {
+  showResults(fortune, juuniunResults, tsuuhenResults, greatFortuneCycles, displayYear, meta = {}) {
+    this.displayYear = displayYear;
+    this.meta = meta;
     this.renderFortuneTable(fortune, juuniunResults, tsuuhenResults);
-    this.renderGreatFortune(greatFortuneCycles, year);
+    this.renderGreatFortune(greatFortuneCycles, displayYear);
     this.elements.resultSection.style.display = "block";
   }
 

--- a/chrome-extension/tests/app/AppController.test.js
+++ b/chrome-extension/tests/app/AppController.test.js
@@ -1,0 +1,314 @@
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { AppController } from '../../js/app/AppController.js';
+import { FortuneCalculator } from '../../js/core/FortuneCalculator.js';
+import { GreatFortuneCalculator } from '../../js/core/GreatFortuneCalculator.js';
+import { JuuniunCalculator } from '../../js/core/JuuniunCalculator.js';
+import { TsuuhenCalculator } from '../../js/core/TsuuhenCalculator.js';
+import { TimeCorrectionService } from '../../js/core/TimeCorrectionService.js';
+import { SHI_MODE } from '../../js/utils/constants.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = path.resolve(__dirname, '../../data');
+const master = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'prefecture_longitude.json'), 'utf8'));
+
+class MockDataLoader {
+  constructor(basePath) {
+    this.basePath = basePath;
+  }
+
+  async loadJSON(filename) {
+    return JSON.parse(fs.readFileSync(path.join(this.basePath, filename), 'utf8'));
+  }
+
+  async loadSolarTerms() { return this.loadJSON('solar_terms.json'); }
+  async loadStemBranchMaster() { return this.loadJSON('stem_branch_master.json'); }
+  async loadJuuniunMaster() { return this.loadJSON('juuniin_master.json'); }
+  async loadPrefectureLongitude() { return JSON.parse(JSON.stringify(master)); }
+}
+
+function pillar(result, key) {
+  return `${result[key].stem}${result[key].branch}`;
+}
+
+async function createController() {
+  const loader = new MockDataLoader(DATA_DIR);
+  const fortuneCalculator = new FortuneCalculator(loader);
+  await fortuneCalculator.initialize();
+  const greatFortuneCalculator = new GreatFortuneCalculator(fortuneCalculator);
+  await greatFortuneCalculator.initialize();
+  const juuniunCalculator = new JuuniunCalculator(loader);
+  await juuniunCalculator.initialize();
+
+  return new AppController({
+    fortuneCalculator,
+    greatFortuneCalculator,
+    juuniunCalculator,
+    tsuuhenCalculator: new TsuuhenCalculator(),
+    timeCorrectionService: new TimeCorrectionService(master),
+  });
+}
+
+const BASE_INPUT = {
+  year: 2023,
+  month: 6,
+  day: 15,
+  hour: 12,
+  minute: 0,
+  gender: '男性',
+  prefectureCode: null,
+  offsetMinutes: 0,
+  shiMode: SHI_MODE.SWITCH_23,
+};
+
+let controller;
+
+test('P5 controller initialize wiring', async () => {
+  controller = await createController();
+  assert.ok(controller.timeCorrectionService);
+});
+
+test('IX-01 22:50 plus 20min switch23 is 子 and next-day pillar; year/month stay on 23h', async () => {
+  const result = controller.runCalculation({
+    ...BASE_INPUT,
+    hour: 22,
+    minute: 50,
+    offsetMinutes: 20,
+    shiMode: SHI_MODE.SWITCH_23,
+  });
+  assert.deepStrictEqual(result.correction.corrected, {
+    year: 2023, month: 6, day: 15, hour: 23, minute: 10,
+  });
+  assert.strictEqual(result.fortune.hourPillar.branch, '子');
+  assert.strictEqual(pillar(result.fortune, 'dayPillar'), '乙巳');
+  assert.strictEqual(pillar(result.fortune, 'yearPillar'), '癸卯');
+  assert.strictEqual(pillar(result.fortune, 'monthPillar'), '戊午');
+  assert.strictEqual(result.displayYear, 2023);
+});
+
+test('IX-02 23:50 plus 20min switch23 rolls to next day 00h without extra +1', async () => {
+  const result = controller.runCalculation({
+    ...BASE_INPUT,
+    hour: 23,
+    minute: 50,
+    offsetMinutes: 20,
+    shiMode: SHI_MODE.SWITCH_23,
+  });
+  assert.deepStrictEqual(result.correction.corrected, {
+    year: 2023, month: 6, day: 16, hour: 0, minute: 10,
+  });
+  assert.strictEqual(result.fortune.hourPillar.branch, '子');
+  assert.strictEqual(pillar(result.fortune, 'dayPillar'), '乙巳');
+  assert.strictEqual(pillar(result.fortune, 'yearPillar'), '癸卯');
+  assert.strictEqual(pillar(result.fortune, 'monthPillar'), '戊午');
+});
+
+test('IX-03 22:50 plus 20min switch00 is 亥 and same-day pillar', async () => {
+  const result = controller.runCalculation({
+    ...BASE_INPUT,
+    hour: 22,
+    minute: 50,
+    offsetMinutes: 20,
+    shiMode: SHI_MODE.SWITCH_00,
+  });
+  assert.strictEqual(result.fortune.hourPillar.branch, '亥');
+  assert.strictEqual(pillar(result.fortune, 'dayPillar'), '甲辰');
+  assert.strictEqual(pillar(result.fortune, 'monthPillar'), '戊午');
+});
+
+test('IX-04 23:50 plus 20min switch00 is 子 on the corrected calendar day', async () => {
+  const result = controller.runCalculation({
+    ...BASE_INPUT,
+    hour: 23,
+    minute: 50,
+    offsetMinutes: 20,
+    shiMode: SHI_MODE.SWITCH_00,
+  });
+  assert.strictEqual(result.fortune.hourPillar.branch, '子');
+  assert.strictEqual(pillar(result.fortune, 'dayPillar'), '乙巳');
+  assert.strictEqual(pillar(result.fortune, 'monthPillar'), '戊午');
+});
+
+test('P5-T2 no-time path skips correction, hour pillar, and uses 12:00 for 大運', async () => {
+  const calls = [];
+  const original = controller.greatFortuneCalculator.calculateCycles.bind(controller.greatFortuneCalculator);
+  controller.greatFortuneCalculator.calculateCycles = (...args) => {
+    calls.push(args);
+    return original(...args);
+  };
+
+  const result = controller.runCalculation({
+    ...BASE_INPUT,
+    hour: null,
+    minute: null,
+  });
+
+  controller.greatFortuneCalculator.calculateCycles = original;
+
+  assert.strictEqual(result.correction.applied, false);
+  assert.strictEqual(result.correction.reason, 'no_time');
+  assert.strictEqual(result.fortune.hourPillar, null);
+  assert.strictEqual(result.displayYear, 2023);
+  assert.strictEqual(calls[0][0], 2023);
+  assert.strictEqual(calls[0][1], 6);
+  assert.strictEqual(calls[0][2], 15);
+  assert.strictEqual(calls[0][3], 12);
+  assert.strictEqual(calls[0][4], 0);
+});
+
+test('P5-T3 fortune and great fortune receive the same t_corrected', async () => {
+  const fortuneArgs = [];
+  const cycleArgs = [];
+  const origFortune = controller.fortuneCalculator.calculateFortune.bind(controller.fortuneCalculator);
+  const origCycles = controller.greatFortuneCalculator.calculateCycles.bind(controller.greatFortuneCalculator);
+  controller.fortuneCalculator.calculateFortune = (...args) => {
+    fortuneArgs.push(args);
+    return origFortune(...args);
+  };
+  controller.greatFortuneCalculator.calculateCycles = (...args) => {
+    cycleArgs.push(args);
+    return origCycles(...args);
+  };
+
+  const result = controller.runCalculation({
+    ...BASE_INPUT,
+    prefectureCode: '13',
+    offsetMinutes: 60,
+  });
+
+  controller.fortuneCalculator.calculateFortune = origFortune;
+  controller.greatFortuneCalculator.calculateCycles = origCycles;
+
+  const t = result.correction.corrected;
+  assert.strictEqual(result.correction.applied, true);
+  assert.deepStrictEqual(fortuneArgs[0].slice(0, 5), [t.year, t.month, t.day, t.hour, t.minute]);
+  assert.deepStrictEqual(cycleArgs[0].slice(0, 5), [t.year, t.month, t.day, t.hour, t.minute]);
+});
+
+test('ST-01 correction across 芒種 changes the month pillar', async () => {
+  const before = controller.runCalculation({
+    ...BASE_INPUT,
+    month: 6,
+    day: 7,
+    hour: 2,
+    minute: 50,
+    offsetMinutes: 0,
+  });
+  const after = controller.runCalculation({
+    ...BASE_INPUT,
+    month: 6,
+    day: 7,
+    hour: 2,
+    minute: 50,
+    offsetMinutes: 20,
+  });
+  assert.strictEqual(before.fortune.monthPillar.branch, '巳');
+  assert.strictEqual(after.correction.corrected.hour, 3);
+  assert.strictEqual(after.fortune.monthPillar.branch, '午');
+});
+
+test('P5-T5 solar-term out of range surfaces as calculation error', async () => {
+  await assert.throws(
+    async () => {
+      controller.runCalculation({
+        ...BASE_INPUT,
+        year: 2101,
+        hour: 12,
+        minute: 0,
+      });
+    },
+    '見つかりません',
+    'missing solar term data should throw'
+  );
+
+  const errors = [];
+  controller.formRenderer = { hideError() {}, showError(message) { errors.push(message); } };
+  controller.inputManager = {
+    getFormInput: () => ({ ...BASE_INPUT, year: 2101, hour: 12, minute: 0 }),
+  };
+  controller.resultRenderer = { showResults() {} };
+  await controller.handleCalculate();
+  assert.ok(errors[0].includes('見つかりません'));
+});
+
+test('P5-T4 displayYear uses t_corrected year when crossing the year', async () => {
+  const result = controller.runCalculation({
+    ...BASE_INPUT,
+    year: 2023,
+    month: 12,
+    day: 31,
+    hour: 23,
+    minute: 50,
+    offsetMinutes: 20,
+  });
+  assert.strictEqual(result.correction.corrected.year, 2024);
+  assert.strictEqual(result.displayYear, 2024);
+});
+
+test('handleCalculate passes displayYear and meta to showResults', async () => {
+  const shown = [];
+  const errors = [];
+  controller.formRenderer = { hideError() {}, showError(message) { errors.push(message); } };
+  controller.inputManager = {
+    getFormInput: () => ({ ...BASE_INPUT, hour: 8, minute: 30, prefectureCode: '13' }),
+  };
+  controller.resultRenderer = {
+    showResults(...args) { shown.push(args); },
+  };
+
+  await controller.handleCalculate();
+  assert.strictEqual(errors.length, 0);
+  assert.strictEqual(shown.length, 1);
+  const meta = shown[0][5];
+  assert.strictEqual(shown[0][4], meta.correction.corrected.year);
+  assert.strictEqual(meta.correction.applied, true);
+  assert.strictEqual(meta.shiMode, SHI_MODE.SWITCH_23);
+});
+
+test('P5-T6 missing longitude master fails initialization', async () => {
+  const errors = [];
+  const app = new AppController({
+    formRenderer: {
+      showError(message) { errors.push(message); },
+      populatePrefectures() {},
+      onSubmit() {},
+      onClear() {},
+      onPaste() {},
+    },
+    resultRenderer: { onSavePNG() {} },
+    inputManager: { setLongitudeMaster() {} },
+    dataLoader: {
+      async loadPrefectureLongitude() {
+        throw new Error('経度マスタを読み込めません');
+      },
+    },
+  });
+  await app.initialize();
+  assert.strictEqual(app.initialized, false);
+  assert.ok(errors[0].includes('初期化'));
+  assert.ok(errors[0].includes('経度マスタ'));
+});
+
+test('P5-T6 malformed longitude master fails initialization', async () => {
+  const errors = [];
+  const app = new AppController({
+    formRenderer: {
+      showError(message) { errors.push(message); },
+      populatePrefectures() {},
+      onSubmit() {},
+      onClear() {},
+      onPaste() {},
+    },
+    resultRenderer: { onSavePNG() {} },
+    inputManager: { setLongitudeMaster() {} },
+    dataLoader: {
+      async loadPrefectureLongitude() {
+        return { referenceMeridianEast: 135, prefectures: [] };
+      },
+    },
+  });
+  await app.initialize();
+  assert.strictEqual(app.initialized, false);
+  assert.ok(errors[0].includes('初期化'));
+});


### PR DESCRIPTION
## Summary
- `AppController`で経度マスタ読込、`TimeCorrectionService`初期化、都道府県セレクトを接続
- 補正後日時をFortune / GreatFortuneへ渡し、子時モードと表示年を伝播
- 時刻未入力時は補正をスキップし、時柱なし・大運12:00へフォールバック
- `ResultRenderer.showResults(..., displayYear, meta)`へ接続
- IX-01〜04、ST-01、時刻未入力、異常系、ResultRenderer配線のテストを追加

## Test plan
- [x] `node chrome-extension/tests/run_tests.js`（91 passed, 0 failed）
- [x] 変更ファイルのLint確認（エラーなし）
- [x] 差分の形式チェック

## Follow-up
- 補正サマリのDOM描画と`clear()`対応はP6で実装する。

Made with [Cursor](https://cursor.com)