### PR TITLE
fix: remove redundant input placeholders

### DIFF
--- a/chrome-extension/sidepanel.html
+++ b/chrome-extension/sidepanel.html
@@ -22,11 +22,11 @@
           <div class="form-group">
             <label>生年月日</label>
             <div class="date-inputs">
-              <input type="number" id="year" placeholder="年" min="1900" max="2100" required>
+              <input type="number" id="year" min="1900" max="2100" required>
               <span>年</span>
-              <input type="number" id="month" placeholder="月" min="1" max="12" required>
+              <input type="number" id="month" min="1" max="12" required>
               <span>月</span>
-              <input type="number" id="day" placeholder="日" min="1" max="31" required>
+              <input type="number" id="day" min="1" max="31" required>
               <span>日</span>
             </div>
           </div>
@@ -35,9 +35,9 @@
           <div class="form-group">
             <label>出生時刻</label>
             <div class="time-inputs">
-              <input type="number" id="hour" placeholder="時" min="0" max="23">
+              <input type="number" id="hour" min="0" max="23">
               <span>時</span>
-              <input type="number" id="minute" placeholder="分" min="0" max="59">
+              <input type="number" id="minute" min="0" max="59">
               <span>分</span>
               <label class="time-unknown-label">
                 <input type="checkbox" id="time-unknown">

--- a/chrome-extension/tests/ui/FormRenderer.v152.test.js
+++ b/chrome-extension/tests/ui/FormRenderer.v152.test.js
@@ -75,6 +75,11 @@ test('V1.5.2 date and time stay on one row in CSS', async () => {
   assert.ok(html.includes('class="date-inputs"'));
   assert.ok(html.includes('class="time-inputs"'));
   assert.ok(html.includes('時刻不明'));
+  assert.ok(!html.includes('placeholder="年"'));
+  assert.ok(!html.includes('placeholder="月"'));
+  assert.ok(!html.includes('placeholder="日"'));
+  assert.ok(!html.includes('placeholder="時"'));
+  assert.ok(!html.includes('placeholder="分"'));
 });
 
 test('V1.5.2 time-unknown disables hour and minute and clears them', async () => {


### PR DESCRIPTION
## Summary
- 年・月・日・時・分の入力ボックスから、ラベルと重複するプレースホルダを削除
- 年月日・時刻の1行レイアウトと時刻不明チェックの表示を維持
- プレースホルダが残っていないことをV1.5.2 UIテストで確認

## Test plan
- [x] `node tests/run_tests.js`（118 passed, 0 failed）
- [x] `TZ=UTC node tests/run_tests.js`（118 passed, 0 failed）
- [x] `TZ=Pacific/Kiritimati node tests/run_tests.js`（118 passed, 0 failed）
- [x] 変更テストのLint確認（エラーなし）
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)